### PR TITLE
Fix memif runtime crashes

### DIFF
--- a/src/vnet/devices/memif/cli.c
+++ b/src/vnet/devices/memif/cli.c
@@ -63,7 +63,8 @@ memif_create_command_fn (vlib_main_t * vm, unformat_input_t * input,
 
   r = memif_create_if (vm, &args);
 
-  if (r == VNET_API_ERROR_SYSCALL_ERROR_1)
+  if (r <= VNET_API_ERROR_SYSCALL_ERROR_1
+      && r >= VNET_API_ERROR_SYSCALL_ERROR_10)
     return clib_error_return (0, "%s (errno %d)", strerror (errno), errno);
 
   if (r == VNET_API_ERROR_INVALID_INTERFACE)
@@ -133,7 +134,7 @@ memif_show_command_fn (vlib_main_t * vm, unformat_input_t * input,
   pool_foreach (mif, mm->interfaces,
     ({
        vlib_cli_output (vm, "interface %U", format_vnet_sw_if_index_name, vnm, mif->sw_if_index);
-       vlib_cli_output (vm, "  fd %d file %s", mif->fd,
+       vlib_cli_output (vm, "  sock-fd %d conn-fd %d file %s", mif->sock_fd, mif->conn_fd,
 			mif->socket_file_name);
        vlib_cli_output (vm, "  ring-size %u num-c2s-rings %u num-s2c-rings %u buffer_size %u",
 			(1 << mif->log2_ring_size),

--- a/src/vnet/devices/memif/memif.c
+++ b/src/vnet/devices/memif/memif.c
@@ -32,6 +32,8 @@
 #include <vnet/ethernet/ethernet.h>
 #include <vnet/devices/memif/memif.h>
 
+memif_main_t memif_main;
+
 static u32
 memif_eth_flag_change (vnet_main_t * vnm, vnet_hw_interface_t * hi, u32 flags)
 {
@@ -44,12 +46,43 @@ memif_connect (vlib_main_t * vm, memif_if_t * mif)
 {
   vnet_main_t *vnm = vnet_get_main ();
   int num_rings = mif->num_s2m_rings + mif->num_m2s_rings;
+  memif_ring_data_t *rd = NULL;
 
   vec_validate_aligned (mif->ring_data, num_rings - 1, CLIB_CACHE_LINE_BYTES);
+  vec_foreach (rd, mif->ring_data)
+  {
+    rd->last_head = 0;
+  }
 
   mif->flags |= MEMIF_IF_FLAG_CONNECTED;
   vnet_hw_interface_set_flags (vnm, mif->hw_if_index,
 			       VNET_HW_INTERFACE_FLAG_LINK_UP);
+}
+
+static void
+memif_disconnect (vlib_main_t * vm, memif_if_t * mif)
+{
+  vnet_main_t *vnm = vnet_get_main ();
+
+  mif->flags &= ~MEMIF_IF_FLAG_CONNECTED;
+  vnet_hw_interface_set_flags (vnm, mif->hw_if_index, 0);
+}
+
+static void
+close_memif_conn (memif_main_t * mm, memif_if_t * mif)
+{
+  if (mif->conn_file_index != ~0)
+    {
+      unix_file_del (&unix_main, unix_main.file_pool + mif->conn_file_index);
+      mif->conn_file_index = ~0;
+    }
+  if (mif->conn_fd > -1)
+    {
+      close (mif->conn_fd);
+      mif->conn_fd = -1;
+    }
+  // TODO: properly munmap + close memif-owned shared memory segments
+  vec_free(mif->regions);
 }
 
 static clib_error_t *
@@ -57,7 +90,7 @@ memif_fd_read_ready (unix_file_t * uf)
 {
   memif_main_t *mm = &memif_main;
   vlib_main_t *vm = vlib_get_main ();
-  char ctl[256];
+  char ctl[CMSG_SPACE (sizeof (int)) + CMSG_SPACE (sizeof (struct ucred))];
   struct msghdr mh;
   struct iovec iov[1];
   struct ucred *cr = 0;
@@ -79,6 +112,12 @@ memif_fd_read_ready (unix_file_t * uf)
   size = recvmsg (uf->file_descriptor, &mh, 0);
   if (size != sizeof (memif_msg_t))
     {
+      if (0 == size)
+	{
+	  close_memif_conn (mm, mif);
+	  memif_disconnect (vm, mif);
+	  return 0;
+	}
       // TODO better error handling
       clib_unix_error ("recvmsg");
       return 0;
@@ -125,25 +164,30 @@ memif_fd_accept_ready (unix_file_t * uf)
 {
   memif_main_t *mm = &memif_main;
   memif_if_t *mif;
-  int client_fd, client_len;
+  int addr_len;
   struct sockaddr_un client;
   unix_file_t template = { 0 };
 
   mif = pool_elt_at_index (mm->interfaces, uf->private_data);
 
-  client_len = sizeof (client);
-  client_fd = accept (uf->file_descriptor,
-		      (struct sockaddr *) &client,
-		      (socklen_t *) & client_len);
+  if (mif->conn_fd > -1)
+    {
+      clib_unix_warning ("already connected/connecting");
+      return 0;
+    }
 
-  if (client_fd < 0)
+  addr_len = sizeof (client);
+  mif->conn_fd = accept (uf->file_descriptor,
+			 (struct sockaddr *) &client,
+			 (socklen_t *) & addr_len);
+
+  if (mif->conn_fd < 0)
     return clib_error_return_unix (0, "accept");
 
   template.read_function = memif_fd_read_ready;
-  template.file_descriptor = client_fd;
-  mif->unix_file_index = unix_file_add (&unix_main, &template);
-
-  mif->fd = client_fd;
+  template.file_descriptor = mif->conn_fd;
+  template.private_data = mif->if_index;
+  mif->conn_file_index = unix_file_add (&unix_main, &template);
 
   return 0;
 }
@@ -155,12 +199,11 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
   memif_msg_t msg;
   struct msghdr mh = { 0 };
   struct iovec iov[1];
-  struct cmsghdr *cmsghdr;
+  struct cmsghdr *cmsg;
   int mfd;
   int rv;
-  //FIXME 1024 ?
-  char ctl[1024];
-  memif_ring_t *ring;
+  char ctl[CMSG_SPACE (sizeof (int))];
+  memif_ring_t *ring = NULL;
   int i, j;
   void *shm;
   u64 buffer_offset;
@@ -203,7 +246,8 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
       ring->head = ring->tail = 0;
       for (j = 0; j < (1 << mif->log2_ring_size); j++)
 	{
-	  u16 slot = i * (1 << mif->log2_ring_size);
+	  u16 slot = i * (1 << mif->log2_ring_size) + j;
+	  ring->desc[j].region = 0;
 	  ring->desc[j].offset = buffer_offset + (slot * mif->buffer_size);
 	  ring->desc[j].buffer_length = mif->buffer_size;
 	}
@@ -214,7 +258,9 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
       ring->head = ring->tail = 0;
       for (j = 0; j < (1 << mif->log2_ring_size); j++)
 	{
-	  u16 slot = (i + mif->num_s2m_rings) * (1 << mif->log2_ring_size);
+	  u16 slot =
+	    (i + mif->num_s2m_rings) * (1 << mif->log2_ring_size) + j;
+	  ring->desc[j].region = 0;
 	  ring->desc[j].offset = buffer_offset + (slot * mif->buffer_size);
 	  ring->desc[j].buffer_length = mif->buffer_size;
 	}
@@ -227,13 +273,14 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
 
   memset (&ctl, 0, sizeof (ctl));
   mh.msg_control = ctl;
-  mh.msg_controllen = CMSG_SPACE (sizeof (int));
-  cmsghdr = CMSG_FIRSTHDR (&mh);
-  cmsghdr->cmsg_len = CMSG_LEN (sizeof (int));
-  cmsghdr->cmsg_level = SOL_SOCKET;
-  cmsghdr->cmsg_type = SCM_RIGHTS;
-  clib_memcpy (CMSG_DATA (cmsghdr), &mfd, sizeof (mfd));
-  rv = sendmsg (mif->fd, &mh, 0);
+  mh.msg_controllen = sizeof (ctl);
+  cmsg = CMSG_FIRSTHDR (&mh);
+  cmsg->cmsg_len = CMSG_LEN (sizeof (mfd));
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  clib_memcpy (CMSG_DATA (cmsg), &mfd, sizeof (mfd));
+
+  rv = sendmsg (mif->conn_fd, &mh, 0);
 
   if (rv < 0)
     clib_unix_warning ("sendmsg");
@@ -248,7 +295,8 @@ memif_process (vlib_main_t * vm, vlib_node_runtime_t * rt, vlib_frame_t * f)
   memif_if_t *mif;
   struct sockaddr_un sun;
   int sockfd;
-  f64 timeout = 3153600000.0 /* 100 years */ ;
+#define UNREACHABLE_TIMEOUT  3153600000.0	/* 100 years */
+  f64 timeout = UNREACHABLE_TIMEOUT;
   uword *event_data = 0;
   unix_file_t template = { 0 };
 
@@ -262,7 +310,14 @@ memif_process (vlib_main_t * vm, vlib_node_runtime_t * rt, vlib_frame_t * f)
       vlib_process_get_events (vm, &event_data);
       vec_reset_length (event_data);
 
-      timeout = 3.0;
+      if (pool_elts (mm->interfaces) > 0)
+	{
+	  timeout = 3.0;
+	}
+      else
+	{
+	  timeout = UNREACHABLE_TIMEOUT;
+	}
 
       vec_foreach (mif, mm->interfaces)
       {
@@ -282,9 +337,10 @@ memif_process (vlib_main_t * vm, vlib_node_runtime_t * rt, vlib_frame_t * f)
 		 sizeof (struct sockaddr_un)) == 0)
 	      {
 		//vui->sock_errno = 0;
-		mif->fd = sockfd;
+		mif->conn_fd = sockfd;
 		template.file_descriptor = sockfd;
-		mif->unix_file_index = unix_file_add (&unix_main, &template);
+		template.private_data = mif->if_index;
+		mif->conn_file_index = unix_file_add (&unix_main, &template);
 		memif_connect_master (vm, mif);
 
 		/* grab another fd */
@@ -309,18 +365,28 @@ VLIB_REGISTER_NODE (memif_process_node,static) = {
 static void
 close_memif_if (memif_main_t * mm, memif_if_t * mif)
 {
-  if (mif->unix_file_index != ~0)
-    {
-      unix_file_del (&unix_main, unix_main.file_pool + mif->unix_file_index);
-      mif->unix_file_index = ~0;
-    }
+  close_memif_conn (mm, mif);
 
-  if (mif->fd > -1)
-    close (mif->fd);
+  if (mif->sock_file_index != ~0)
+    {
+      unix_file_del (&unix_main, unix_main.file_pool + mif->sock_file_index);
+      mif->sock_file_index = ~0;
+    }
+  if (mif->sock_fd > -1)
+    {
+      close (mif->sock_fd);
+      mif->sock_fd = -1;
+    }
+  if (mif->lockp != 0)
+    {
+      clib_mem_free ((void *) mif->lockp);
+      mif->lockp = 0;
+    }
 
   mhash_unset (&mm->if_index_by_sock_file_name, mif->socket_file_name,
 	       &mif->if_index);
   vec_free (mif->socket_file_name);
+  vec_free (mif->ring_data);
 
   memset (mif, 0, sizeof (*mif));
   pool_put (mm->interfaces, mif);
@@ -371,7 +437,11 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
     return VNET_API_ERROR_SUBIF_ALREADY_EXISTS;
 
   pool_get (mm->interfaces, mif);
+  memset (mif, 0, sizeof (*mif));
   mif->if_index = mif - mm->interfaces;
+  mif->sock_fd = mif->conn_fd = -1;
+  mif->sock_file_index = mif->conn_file_index = ~0;
+  mif->hw_if_index = ~0;
 
   if (tm->n_vlib_mains > 1)
     {
@@ -379,6 +449,7 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
 					   CLIB_CACHE_LINE_BYTES);
       memset ((void *) mif->lockp, 0, CLIB_CACHE_LINE_BYTES);
     }
+
   // TODO set mac manually
   {
     f64 now = vlib_time_now (vm);
@@ -445,26 +516,26 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
 	}
       if (bind (fd, (struct sockaddr *) &un, sizeof (un)) == -1)
 	{
-	  ret = VNET_API_ERROR_SYSCALL_ERROR_3;
+	  ret = VNET_API_ERROR_SYSCALL_ERROR_4;
 	  goto error;
 	}
 
       if (listen (fd, 1) == -1)
 	{
-	  ret = VNET_API_ERROR_SYSCALL_ERROR_4;
+	  ret = VNET_API_ERROR_SYSCALL_ERROR_5;
 	  goto error;
 	}
 
       unix_file_t template = { 0 };
       template.read_function = memif_fd_accept_ready;
-      template.file_descriptor = mif->fd = fd;
+      template.file_descriptor = mif->sock_fd = fd;
       template.private_data = mif->if_index;
-      mif->unix_file_index = unix_file_add (&unix_main, &template);
+      mif->sock_file_index = unix_file_add (&unix_main, &template);
     }
   else
     {
       mif->flags |= MEMIF_IF_FLAG_IS_SLAVE;
-      mif->fd = -1;
+      mif->sock_fd = -1;
     }
 
 #if 0
@@ -479,6 +550,11 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
   return 0;
 
 error:
+  if (mif->hw_if_index != ~0)
+    {
+      ethernet_delete_interface (vnm, mif->hw_if_index);
+      mif->hw_if_index = ~0;
+    }
   close_memif_if (mm, mif);
   return ret;
 }

--- a/src/vnet/devices/memif/memif.c
+++ b/src/vnet/devices/memif/memif.c
@@ -66,11 +66,7 @@ memif_disconnect (vlib_main_t * vm, memif_if_t * mif)
 
   mif->flags &= ~MEMIF_IF_FLAG_CONNECTED;
   vnet_hw_interface_set_flags (vnm, mif->hw_if_index, 0);
-}
 
-static void
-close_memif_conn (memif_main_t * mm, memif_if_t * mif)
-{
   if (mif->conn_file_index != ~0)
     {
       unix_file_del (&unix_main, unix_main.file_pool + mif->conn_file_index);
@@ -114,7 +110,6 @@ memif_fd_read_ready (unix_file_t * uf)
     {
       if (0 == size)
 	{
-	  close_memif_conn (mm, mif);
 	  memif_disconnect (vm, mif);
 	  return 0;
 	}
@@ -365,7 +360,9 @@ VLIB_REGISTER_NODE (memif_process_node,static) = {
 static void
 close_memif_if (memif_main_t * mm, memif_if_t * mif)
 {
-  close_memif_conn (mm, mif);
+  vlib_main_t *vm = vlib_get_main ();
+
+  memif_disconnect (vm, mif);
 
   if (mif->sock_file_index != ~0)
     {

--- a/src/vnet/devices/memif/memif.c
+++ b/src/vnet/devices/memif/memif.c
@@ -137,6 +137,8 @@ memif_fd_read_ready (unix_file_t * uf)
 	     mfd, 0)) == MAP_FAILED)
     clib_unix_error ("mmap");
 
+  // TODO: check cookie
+
   mif->log2_ring_size = msg.log2_ring_size;
   mif->num_s2m_rings = msg.num_s2m_rings;
   mif->num_m2s_rings = msg.num_m2s_rings;

--- a/src/vnet/devices/memif/memif.c
+++ b/src/vnet/devices/memif/memif.c
@@ -72,11 +72,6 @@ memif_disconnect (vlib_main_t * vm, memif_if_t * mif)
       unix_file_del (&unix_main, unix_main.file_pool + mif->conn_file_index);
       mif->conn_file_index = ~0;
     }
-  if (mif->conn_fd > -1)
-    {
-      close (mif->conn_fd);
-      mif->conn_fd = -1;
-    }
   // TODO: properly munmap + close memif-owned shared memory segments
   vec_free(mif->regions);
 }
@@ -368,11 +363,6 @@ close_memif_if (memif_main_t * mm, memif_if_t * mif)
     {
       unix_file_del (&unix_main, unix_main.file_pool + mif->sock_file_index);
       mif->sock_file_index = ~0;
-    }
-  if (mif->sock_fd > -1)
-    {
-      close (mif->sock_fd);
-      mif->sock_fd = -1;
     }
   if (mif->lockp != 0)
     {

--- a/src/vnet/devices/memif/memif.h
+++ b/src/vnet/devices/memif/memif.h
@@ -75,11 +75,14 @@ typedef struct
 
   u32 per_interface_next_index;
 
-  int fd;
-  u32 unix_file_index;
+  int sock_fd;
+  int conn_fd;
+  u32 sock_file_index;
+  u32 conn_file_index;
   u8 *socket_file_name;
 
   void **regions;
+
   u8 log2_ring_size;
   u8 num_s2m_rings;
   u8 num_m2s_rings;
@@ -113,7 +116,7 @@ typedef struct
   u32 input_cpu_count;
 } memif_main_t;
 
-memif_main_t memif_main;
+extern memif_main_t memif_main;
 extern vnet_device_class_t memif_device_class;
 extern vlib_node_registration_t memif_input_node;
 


### PR DESCRIPTION
This patch request includes:
 - fixed slave/master re-connection crashes
 - fixed packet copying -- packets were stripped of the last cache line
 - minor fixes in the pre-fetching code
 - if the link is up but the interface is administratively put down, then the incoming packets are continuously being skipped so that the sender is not blocked