### PR TITLE
Fix memif re-connection.

### DIFF
--- a/src/vnet/devices/memif/cli.c
+++ b/src/vnet/devices/memif/cli.c
@@ -63,7 +63,8 @@ memif_create_command_fn (vlib_main_t * vm, unformat_input_t * input,
 
   r = memif_create_if (vm, &args);
 
-  if (r == VNET_API_ERROR_SYSCALL_ERROR_1)
+  if (r <= VNET_API_ERROR_SYSCALL_ERROR_1
+      && r >= VNET_API_ERROR_SYSCALL_ERROR_10)
     return clib_error_return (0, "%s (errno %d)", strerror (errno), errno);
 
   if (r == VNET_API_ERROR_INVALID_INTERFACE)
@@ -133,7 +134,7 @@ memif_show_command_fn (vlib_main_t * vm, unformat_input_t * input,
   pool_foreach (mif, mm->interfaces,
     ({
        vlib_cli_output (vm, "interface %U", format_vnet_sw_if_index_name, vnm, mif->sw_if_index);
-       vlib_cli_output (vm, "  fd %d file %s", mif->fd,
+       vlib_cli_output (vm, "  sock-fd %d conn-fd %d file %s", mif->sock_fd, mif->conn_fd,
 			mif->socket_file_name);
        vlib_cli_output (vm, "  ring-size %u num-c2s-rings %u num-s2c-rings %u buffer_size %u",
 			(1 << mif->log2_ring_size),

--- a/src/vnet/devices/memif/memif.h
+++ b/src/vnet/devices/memif/memif.h
@@ -75,11 +75,14 @@ typedef struct
 
   u32 per_interface_next_index;
 
-  int fd;
-  u32 unix_file_index;
+  int sock_fd;
+  int conn_fd;
+  u32 sock_file_index;
+  u32 conn_file_index;
   u8 *socket_file_name;
 
   void **regions;
+
   u8 log2_ring_size;
   u8 num_s2m_rings;
   u8 num_m2s_rings;
@@ -113,7 +116,7 @@ typedef struct
   u32 input_cpu_count;
 } memif_main_t;
 
-memif_main_t memif_main;
+extern memif_main_t memif_main;
 extern vnet_device_class_t memif_device_class;
 extern vlib_node_registration_t memif_input_node;
 


### PR DESCRIPTION
This patch request makes memif to behave correctly even if master
or slave drops the connection and possibly re-establishes it again.

Most of this code will be re-written for the single-listener socket
proposal, but for the time being it will make the memif interface easier
to play with by getting rid of the runtime crashes.