### PR TITLE
Refactorization of the memif connection handling

### DIFF
--- a/src/plugins/memif/cli.c
+++ b/src/plugins/memif/cli.c
@@ -54,7 +54,7 @@ memif_create_command_fn (vlib_main_t * vm, unformat_input_t * input,
 	args.is_master = 0;
       else if (unformat (line_input, "hw-addr %U",
 			 unformat_ethernet_address, args.hw_addr))
-	  args.hw_addr_set = 1;
+	args.hw_addr_set = 1;
       else
 	return clib_error_return (0, "unknown input `%U'",
 				  format_unformat_error, input);

--- a/src/plugins/memif/cli.c
+++ b/src/plugins/memif/cli.c
@@ -32,6 +32,7 @@ memif_create_command_fn (vlib_main_t * vm, unformat_input_t * input,
   int r;
   u32 ring_size = 1024;
   memif_create_if_args_t args = { 0 };
+  args.buffer_size = 2048;
 
   /* Get a line of input. */
   if (!unformat_user (input, unformat_line_input, line_input))
@@ -39,22 +40,26 @@ memif_create_command_fn (vlib_main_t * vm, unformat_input_t * input,
 
   while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
     {
-      if (unformat (line_input, "socket %s", &args.socket_file_name))
+      if (unformat (line_input, "key %lu", &args.key))
+	;
+      else if (unformat (line_input, "socket %s", &args.socket_filename))
 	;
       else if (unformat (line_input, "ring-size %u", &ring_size))
+	;
+      else if (unformat (line_input, "buffer-size %u", &args.buffer_size))
 	;
       else if (unformat (line_input, "master"))
 	args.is_master = 1;
       else if (unformat (line_input, "slave"))
 	args.is_master = 0;
+      else if (unformat (line_input, "hw-addr %U",
+			 unformat_ethernet_address, args.hw_addr))
+	  args.hw_addr_set = 1;
       else
 	return clib_error_return (0, "unknown input `%U'",
 				  format_unformat_error, input);
     }
   unformat_free (line_input);
-
-  if (args.socket_file_name == NULL)
-    return clib_error_return (0, "missing socket file name");
 
   if (!is_pow2 (ring_size))
     return clib_error_return (0, "ring size must be power of 2");
@@ -79,7 +84,9 @@ memif_create_command_fn (vlib_main_t * vm, unformat_input_t * input,
 /* *INDENT-OFF* */
 VLIB_CLI_COMMAND (memif_create_command, static) = {
   .path = "create memif",
-  .short_help = "create memif socket <name> <master|slave>",
+  .short_help = "create memif [key <key>] [socket <path>] "
+                "[ring-size <size>] [buffer-size <size>] [hw-addr <mac-address>] "
+		"<master|slave>",
   .function = memif_create_command_fn,
 };
 /* *INDENT-ON* */
@@ -89,7 +96,8 @@ memif_delete_command_fn (vlib_main_t * vm, unformat_input_t * input,
 			 vlib_cli_command_t * cmd)
 {
   unformat_input_t _line_input, *line_input = &_line_input;
-  u8 *host_if_name = NULL;
+  u64 key = 0;
+  u8 key_defined = 0;
 
   /* Get a line of input. */
   if (!unformat_user (input, unformat_line_input, line_input))
@@ -97,18 +105,18 @@ memif_delete_command_fn (vlib_main_t * vm, unformat_input_t * input,
 
   while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
     {
-      if (unformat (line_input, "name %s", &host_if_name))
-	;
+      if (unformat (line_input, "key %lu", &key))
+	key_defined = 1;
       else
 	return clib_error_return (0, "unknown input `%U'",
 				  format_unformat_error, input);
     }
   unformat_free (line_input);
 
-  if (host_if_name == NULL)
-    return clib_error_return (0, "missing host interface name");
+  if (!key_defined)
+    return clib_error_return (0, "missing key");
 
-  memif_delete_if (vm, host_if_name);
+  memif_delete_if (vm, key);
 
   return 0;
 }
@@ -116,7 +124,7 @@ memif_delete_command_fn (vlib_main_t * vm, unformat_input_t * input,
 /* *INDENT-OFF* */
 VLIB_CLI_COMMAND (memif_delete_command, static) = {
   .path = "delete memif",
-  .short_help = "delete memif name <interface name>",
+  .short_help = "delete memif key <key-value>",
   .function = memif_delete_command_fn,
 };
 /* *INDENT-ON* */
@@ -133,25 +141,34 @@ memif_show_command_fn (vlib_main_t * vm, unformat_input_t * input,
   /* *INDENT-OFF* */
   pool_foreach (mif, mm->interfaces,
     ({
-       vlib_cli_output (vm, "interface %U", format_vnet_sw_if_index_name, vnm, mif->sw_if_index);
-       vlib_cli_output (vm, "  sock-fd %d conn-fd %d file %s", mif->sock_fd, mif->conn_fd,
-			mif->socket_file_name);
+       vlib_cli_output (vm, "interface %U", format_vnet_sw_if_index_name,
+			vnm, mif->sw_if_index);
+       vlib_cli_output (vm, "  key %lu file %s", mif->key,
+			mif->socket_filename);
+       vlib_cli_output (vm, "  listener %d conn-fd %d", mif->listener_index,
+			mif->connection.fd);
        vlib_cli_output (vm, "  ring-size %u num-c2s-rings %u num-s2c-rings %u buffer_size %u",
 			(1 << mif->log2_ring_size),
 			mif->num_s2m_rings,
 			mif->num_m2s_rings,
 			mif->buffer_size);
-       for (i=0; i< mif->num_s2m_rings; i++)
+       for (i=0; i < mif->num_s2m_rings; i++)
          {
 	   memif_ring_t * ring = memif_get_ring (mif, MEMIF_RING_S2M, i);
-	   vlib_cli_output (vm, "  slave-to-master ring %u:", i);
-	   vlib_cli_output (vm, "    head %u tail %u", ring->head, ring->tail);
+	   if (ring)
+	     {
+	       vlib_cli_output (vm, "  slave-to-master ring %u:", i);
+	       vlib_cli_output (vm, "    head %u tail %u", ring->head, ring->tail);
+	     }
 	 }
-       for (i=0; i< mif->num_m2s_rings; i++)
+       for (i=0; i < mif->num_m2s_rings; i++)
          {
 	   memif_ring_t * ring = memif_get_ring (mif, MEMIF_RING_M2S, i);
-	   vlib_cli_output (vm, "  master-to-slave ring %u:", i);
-	   vlib_cli_output (vm, "    head %u tail %u", ring->head, ring->tail);
+	   if (ring)
+	     {
+	       vlib_cli_output (vm, "  master-to-slave ring %u:", i);
+	       vlib_cli_output (vm, "    head %u tail %u", ring->head, ring->tail);
+	     }
 	 }
     }));
   /* *INDENT-ON* */

--- a/src/plugins/memif/device.c
+++ b/src/plugins/memif/device.c
@@ -277,7 +277,7 @@ memif_interface_admin_up_down (vnet_main_t * vnm, u32 hw_if_index, u32 flags)
       mif->flags &= ~MEMIF_IF_FLAG_ADMIN_UP;
       if (!(mif->flags & MEMIF_IF_FLAG_DELETING)
 	  && mif->connection.index != ~0)
-        {
+	{
 	  msg.version = MEMIF_VERSION;
 	  msg.type = MEMIF_MSG_TYPE_DISCONNECT;
 	  send (mif->connection.fd, &msg, sizeof (msg), 0);

--- a/src/plugins/memif/memif.c
+++ b/src/plugins/memif/memif.c
@@ -103,7 +103,7 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
 {
   memif_main_t *mm = &memif_main;
   vlib_main_t *vm = vlib_get_main ();
-  unix_file_t* uf = vec_elt_at_index (unix_main.file_pool,
+  unix_file_t *uf = vec_elt_at_index (unix_main.file_pool,
 				      pending_connection->connection.index);
   memif_if_t *mif = 0;
   memif_msg_t resp = {0};

--- a/src/plugins/memif/memif.c
+++ b/src/plugins/memif/memif.c
@@ -36,11 +36,25 @@
 
 memif_main_t memif_main;
 
+static clib_error_t * memif_fd_msg_ready (unix_file_t * uf);
+static clib_error_t * memif_fd_auth_ready (unix_file_t * uf);
+
 static u32
 memif_eth_flag_change (vnet_main_t * vnm, vnet_hw_interface_t * hi, u32 flags)
 {
   /* nothing for now */
   return 0;
+}
+
+static void
+memif_remove_pending_connection (
+	memif_pending_connection_t * pending_connection)
+{
+  memif_main_t *mm = &memif_main;
+
+  unix_file_del (&unix_main,
+		 unix_main.file_pool + pending_connection->connection.index);
+  pool_put (mm->pending_connections, pending_connection);
 }
 
 static void
@@ -56,6 +70,7 @@ memif_connect (vlib_main_t * vm, memif_if_t * mif)
     rd->last_head = 0;
   }
 
+  mif->flags &= ~MEMIF_IF_FLAG_CONNECTING;
   mif->flags |= MEMIF_IF_FLAG_CONNECTED;
   vnet_hw_interface_set_flags (vnm, mif->hw_if_index,
 			       VNET_HW_INTERFACE_FLAG_LINK_UP);
@@ -66,35 +81,183 @@ memif_disconnect (vlib_main_t * vm, memif_if_t * mif)
 {
   vnet_main_t *vnm = vnet_get_main ();
 
-  mif->flags &= ~MEMIF_IF_FLAG_CONNECTED;
-  vnet_hw_interface_set_flags (vnm, mif->hw_if_index, 0);
+  mif->flags &= ~(MEMIF_IF_FLAG_CONNECTED | MEMIF_IF_FLAG_CONNECTING);
+  if (mif->hw_if_index != ~0)
+    vnet_hw_interface_set_flags (vnm, mif->hw_if_index, 0);
 
-  if (mif->conn_file_index != ~0)
+  if (mif->connection.index != ~0)
     {
-      unix_file_del (&unix_main, unix_main.file_pool + mif->conn_file_index);
-      mif->conn_file_index = ~0;
-      mif->conn_fd = -1; /* closed in unix_file_del */
+      unix_file_del (&unix_main, unix_main.file_pool + mif->connection.index);
+      mif->connection.index = ~0;
+      mif->connection.fd = -1;	/* closed in unix_file_del */
     }
+
   // TODO: properly munmap + close memif-owned shared memory segments
-  vec_free(mif->regions);
+  vec_free (mif->regions);
 }
 
 static clib_error_t *
-memif_fd_read_ready (unix_file_t * uf)
+memif_process_connect_req (memif_pending_connection_t * pending_connection,
+			   memif_msg_t * req, struct ucred * slave_cr,
+			   int shm_fd)
 {
   memif_main_t *mm = &memif_main;
   vlib_main_t *vm = vlib_get_main ();
-  char ctl[CMSG_SPACE (sizeof (int)) + CMSG_SPACE (sizeof (struct ucred))];
-  struct msghdr mh;
+  unix_file_t* uf = vec_elt_at_index (unix_main.file_pool,
+				      pending_connection->connection.index);
+  memif_if_t *mif = 0;
+  memif_msg_t resp = {0};
+  void *shm;
+  uword *p;
+  u8 retval = 0;
+
+  if (shm_fd == -1)
+    {
+      clib_warning(
+	"Connection request is missing shared memory file descriptor");
+      retval = 1;
+      goto response;
+    }
+
+  if (slave_cr == NULL)
+    {
+      clib_warning("Connection request is missing slave credentials");
+      retval = 2;
+      goto response;
+    }
+
+  p = mhash_get (&mm->if_index_by_key, &req->key);
+  if (!p)
+    {
+      clib_warning("Connection request with unmatched key (%d)", req->key);
+      retval = 3;
+      goto response;
+    }
+
+  mif = vec_elt_at_index(mm->interfaces, *p);
+  if (mif->listener_index != pending_connection->listener_index)
+    {
+      clib_warning(
+	"Connection request with non-matching listener (%d vs. %d)",
+	pending_connection->listener_index,
+	mif->listener_index);
+      retval = 4;
+      goto response;
+    }
+
+  if (mif->flags & MEMIF_IF_FLAG_IS_SLAVE)
+    {
+      clib_warning ("Memif slave does not accept connection requests");
+      retval = 5;
+      goto response;
+    }
+
+  if (mif->connection.fd != -1)
+    {
+      clib_warning ("Memif %d is already connected", mif->key);
+      retval = 6;
+      goto response;
+    }
+
+  if ((mif->flags & MEMIF_IF_FLAG_ADMIN_UP) == 0)
+    {
+      /* just silently decline the request */
+      retval = 7;
+      goto response;
+    }
+
+  if (req->shared_mem_size < sizeof (memif_shm_t))
+    {
+      clib_warning (
+	"Unexpectedly small shared memory segment received from slave.");
+      retval = 8;
+      goto response;
+    }
+
+  if ((shm =
+       mmap (NULL, req->shared_mem_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+	     shm_fd, 0)) == MAP_FAILED)
+    {
+      clib_unix_warning (
+	"Failed to map shared memory segment received from slave memif");
+      retval = 9;
+      goto response;
+    }
+
+  if (((memif_shm_t *) shm)->cookie != 0xdeadbeef)
+    {
+      clib_warning (
+	"Possibly corrupted shared memory segment received from slave memif");
+      munmap (shm, req->shared_mem_size);
+      retval = 10;
+      goto response;
+    }
+
+  mif->log2_ring_size = req->log2_ring_size;
+  mif->num_s2m_rings = req->num_s2m_rings;
+  mif->num_m2s_rings = req->num_m2s_rings;
+  mif->buffer_size = req->buffer_size;
+  mif->remote_pid = slave_cr->pid;
+  mif->remote_uid = slave_cr->uid;
+  vec_add1 (mif->regions, shm);
+
+  /* change context for future messages */
+  mif->connection = pending_connection->connection;
+  uf->read_function = memif_fd_msg_ready;
+  uf->private_data = mif->if_index;
+  pool_put (mm->pending_connections, pending_connection);
+
+  memif_connect (vm, mif);
+
+response:
+  resp.version = MEMIF_VERSION;
+  resp.type = MEMIF_MSG_TYPE_CONNECT_RESP;
+  resp.retval = retval;
+  send (uf->file_descriptor, &resp, sizeof (resp), 0);
+  return 0;
+}
+
+static clib_error_t *
+memif_process_connect_resp (memif_if_t * mif, memif_msg_t * resp)
+{
+  vlib_main_t *vm = vlib_get_main ();
+
+  if ((mif->flags & MEMIF_IF_FLAG_IS_SLAVE) == 0)
+    {
+      clib_warning("Memif master does not accept connection responses");
+      return 0;
+    }
+
+  if ((mif->flags & MEMIF_IF_FLAG_CONNECTING) == 0)
+    {
+      clib_warning("Unexpected connection response");
+      return 0;
+    }
+
+  if (resp->retval == 0)
+    memif_connect (vm, mif);
+  else
+    memif_disconnect (vm, mif);
+
+  return 0;
+}
+
+static clib_error_t *
+memif_process_incoming_msg (unix_file_t * uf, u8 is_pending_connection)
+{
+  memif_main_t *mm = &memif_main;
+  vlib_main_t *vm = vlib_get_main ();
+  memif_if_t *mif = 0;
+  memif_pending_connection_t *pending_connection = 0;
+  memif_msg_t msg = {0};
+  char ctl[CMSG_SPACE (sizeof (int)) + CMSG_SPACE (sizeof (struct ucred))]
+    = {0};
+  struct msghdr mh = {0};
   struct iovec iov[1];
   struct ucred *cr = 0;
-  u32 idx = uf->private_data;
-  memif_if_t *mif = vec_elt_at_index (mm->interfaces, idx);
-  memif_msg_t msg;
   struct cmsghdr *cmsg;
+  int shm_fd = -1;
   ssize_t size;
-  int mfd = -1;
-  void *shm;
 
   iov[0].iov_base = (void *) &msg;
   iov[0].iov_len = sizeof (memif_msg_t);
@@ -103,12 +266,27 @@ memif_fd_read_ready (unix_file_t * uf)
   mh.msg_control = ctl;
   mh.msg_controllen = sizeof (ctl);
 
+  /* grab the appropriate context */
+  if (is_pending_connection)
+    {
+      pending_connection
+	= vec_elt_at_index (mm->pending_connections, uf->private_data);
+    }
+  else
+    {
+      mif = vec_elt_at_index (mm->interfaces, uf->private_data);
+    }
+
+  /* receive the incoming message */
   size = recvmsg (uf->file_descriptor, &mh, 0);
   if (size != sizeof (memif_msg_t))
     {
       if (0 == size)
 	{
-	  memif_disconnect (vm, mif);
+	  if (is_pending_connection)
+	    memif_remove_pending_connection (pending_connection);
+	  else
+	    memif_disconnect (vm, mif);
 	  return 0;
 	}
       // TODO better error handling
@@ -116,78 +294,108 @@ memif_fd_read_ready (unix_file_t * uf)
       return 0;
     }
 
-  /* Process anciliary data */
-  cmsg = CMSG_FIRSTHDR (&mh);
-  while (cmsg)
+  /* check version of the sender's memif plugin */
+  if (msg.version != MEMIF_VERSION)
     {
-      if (cmsg->cmsg_level == SOL_SOCKET
-	  && cmsg->cmsg_type == SCM_CREDENTIALS)
-	cr = (struct ucred *) CMSG_DATA (cmsg);
-      else if (cmsg->cmsg_level == SOL_SOCKET
-	       && cmsg->cmsg_type == SCM_RIGHTS)
-	{
-	  clib_memcpy (&mfd, CMSG_DATA (cmsg), sizeof (mfd));
-	}
-      cmsg = CMSG_NXTHDR (&mh, cmsg);
+      clib_warning ("Memif version mismatch");
+      if (is_pending_connection)
+        memif_remove_pending_connection (pending_connection);
+      return 0;
     }
 
-  if (mfd == -1)
-    return 0;
+  /* process the message based on its type */
+  switch (msg.type)
+    {
+    case MEMIF_MSG_TYPE_CONNECT_REQ:
+      if (!is_pending_connection)
+	{
+	  clib_warning ("Received unexpected connection request");
+	  return 0;
+	}
 
-  if ((shm =
-       mmap (NULL, msg.shared_mem_size, PROT_READ | PROT_WRITE, MAP_SHARED,
-	     mfd, 0)) == MAP_FAILED)
-    clib_unix_error ("mmap");
+      /* Read anciliary data */
+      cmsg = CMSG_FIRSTHDR (&mh);
+      while (cmsg)
+	{
+	  if (cmsg->cmsg_level == SOL_SOCKET
+	      && cmsg->cmsg_type == SCM_CREDENTIALS)
+	    {
+	      cr = (struct ucred *) CMSG_DATA (cmsg);
+	    }
+	  else if (cmsg->cmsg_level == SOL_SOCKET
+		   && cmsg->cmsg_type == SCM_RIGHTS)
+	    {
+	      clib_memcpy (&shm_fd, CMSG_DATA (cmsg), sizeof (shm_fd));
+	    }
+	  cmsg = CMSG_NXTHDR (&mh, cmsg);
+	}
 
-  mif->log2_ring_size = msg.log2_ring_size;
-  mif->num_s2m_rings = msg.num_s2m_rings;
-  mif->num_m2s_rings = msg.num_m2s_rings;
-  mif->buffer_size = msg.buffer_size;
-  mif->remote_pid = cr->pid;
-  mif->remote_uid = cr->uid;
-  vec_add1 (mif->regions, shm);
+      return memif_process_connect_req (pending_connection, &msg,
+					cr, shm_fd);
 
-  memif_connect (vm, mif);
+    case MEMIF_MSG_TYPE_CONNECT_RESP:
+      return memif_process_connect_resp (mif, &msg);
 
-  return 0;
+    case MEMIF_MSG_TYPE_DISCONNECT:
+      if (is_pending_connection)
+        memif_remove_pending_connection (pending_connection);
+      else
+        memif_disconnect (vm, mif);
+      return 0;
+
+    default:
+      clib_warning ("Received unknown message type");
+      return 0;
+    }
+
+ return 0;
+}
+
+static clib_error_t *
+memif_fd_auth_ready (unix_file_t * uf)
+{
+  return memif_process_incoming_msg (uf, 1 /* requires authentication */);
+}
+
+static clib_error_t *
+memif_fd_msg_ready (unix_file_t * uf)
+{
+  return memif_process_incoming_msg (uf, 0 /* already authenticated */);
 }
 
 static clib_error_t *
 memif_fd_accept_ready (unix_file_t * uf)
 {
   memif_main_t *mm = &memif_main;
-  memif_if_t *mif;
+  memif_listener_t *listener = 0;
+  memif_pending_connection_t *pending_connection = 0;
   int addr_len;
   struct sockaddr_un client;
   int conn_fd;
   unix_file_t template = { 0 };
 
-  mif = pool_elt_at_index (mm->interfaces, uf->private_data);
+  listener = pool_elt_at_index (mm->listeners, uf->private_data);
 
   addr_len = sizeof (client);
   conn_fd = accept (uf->file_descriptor,
-		    (struct sockaddr *) &client,
-		    (socklen_t *) & addr_len);
+		    (struct sockaddr *) &client, (socklen_t *) &addr_len);
 
   if (conn_fd < 0)
     return clib_error_return_unix (0, "accept");
 
-  if (mif->conn_fd > -1)
-    {
-      close(conn_fd);
-      clib_unix_warning ("already connected/connecting");
-      return 0;
-    }
+  pool_get (mm->pending_connections, pending_connection);
+  pending_connection->index = pending_connection - mm->pending_connections;
+  pending_connection->listener_index = listener->index;
+  pending_connection->connection.fd = conn_fd;
 
-  template.read_function = memif_fd_read_ready;
+  template.read_function = memif_fd_auth_ready;
   template.file_descriptor = conn_fd;
-  template.private_data = mif->if_index;
-  mif->conn_file_index = unix_file_add (&unix_main, &template);
-  mif->conn_fd = conn_fd;
+  template.private_data = pending_connection->index;
+  pending_connection->connection.index =
+    unix_file_add (&unix_main, &template);
 
   return 0;
 }
-
 
 static void
 memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
@@ -204,6 +412,9 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
   void *shm;
   u64 buffer_offset;
 
+  msg.version = MEMIF_VERSION;
+  msg.type = MEMIF_MSG_TYPE_CONNECT_REQ;
+  msg.key = mif->key;
   msg.log2_ring_size = mif->log2_ring_size;
   msg.num_s2m_rings = mif->num_s2m_rings;
   msg.num_m2s_rings = mif->num_m2s_rings;
@@ -233,7 +444,6 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
     clib_unix_error ("mmap");
 
   vec_add1 (mif->regions, shm);
-
   ((memif_shm_t *) mif->regions[0])->cookie = 0xdeadbeef;
 
   for (i = 0; i < mif->num_s2m_rings; i++)
@@ -276,12 +486,11 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
   cmsg->cmsg_type = SCM_RIGHTS;
   clib_memcpy (CMSG_DATA (cmsg), &mfd, sizeof (mfd));
 
-  rv = sendmsg (mif->conn_fd, &mh, 0);
+  mif->flags |= MEMIF_IF_FLAG_CONNECTING;
 
+  rv = sendmsg (mif->connection.fd, &mh, 0);
   if (rv < 0)
     clib_unix_warning ("sendmsg");
-
-  memif_connect (vm, mif);
 }
 
 static uword
@@ -297,7 +506,7 @@ memif_process (vlib_main_t * vm, vlib_node_runtime_t * rt, vlib_frame_t * f)
 
   sockfd = socket (AF_UNIX, SOCK_STREAM, 0);
   sun.sun_family = AF_UNIX;
-  template.read_function = memif_fd_read_ready;
+  template.read_function = memif_fd_msg_ready;
 
   while (1)
     {
@@ -305,39 +514,44 @@ memif_process (vlib_main_t * vm, vlib_node_runtime_t * rt, vlib_frame_t * f)
       vlib_process_get_events (vm, &event_data);
       vec_reset_length (event_data);
 
+      /* TODO: replace timeout with vlib_process_wait_for_event(_or_clock) */
       timeout = 3.0;
 
-      vec_foreach (mif, mm->interfaces)
-      {
-	if ((mif->flags & MEMIF_IF_FLAG_ADMIN_UP) == 0)
-	  continue;
+      /* *INDENT-OFF* */
+      pool_foreach (mif, mm->interfaces,
+        ({
+	  if ((mif->flags & MEMIF_IF_FLAG_ADMIN_UP) == 0)
+	    continue;
 
-	if (mif->flags & MEMIF_IF_FLAG_CONNECTED)
-	  continue;
+	  if (mif->flags & MEMIF_IF_FLAG_CONNECTING)
+	    continue;
 
-	if (mif->flags & MEMIF_IF_FLAG_IS_SLAVE)
-	  {
-	    strncpy (sun.sun_path, (char *) mif->socket_file_name,
-		     sizeof (sun.sun_path) - 1);
+	  if (mif->flags & MEMIF_IF_FLAG_CONNECTED)
+	    continue;
 
-	    if (connect
-		(sockfd, (struct sockaddr *) &sun,
-		 sizeof (struct sockaddr_un)) == 0)
-	      {
-		//vui->sock_errno = 0;
-		mif->conn_fd = sockfd;
-		template.file_descriptor = sockfd;
-		template.private_data = mif->if_index;
-		mif->conn_file_index = unix_file_add (&unix_main, &template);
-		memif_connect_master (vm, mif);
+	  if (mif->flags & MEMIF_IF_FLAG_IS_SLAVE)
+	    {
+	      strncpy (sun.sun_path, (char *) mif->socket_filename,
+		       sizeof (sun.sun_path) - 1);
 
-		/* grab another fd */
-		sockfd = socket (AF_UNIX, SOCK_STREAM, 0);
-		if (sockfd < 0)
-		  return 0;
-	      }
-	  }
-      }
+	      if (connect
+		  (sockfd, (struct sockaddr *) &sun,
+		   sizeof (struct sockaddr_un)) == 0)
+	        {
+		  mif->connection.fd = sockfd;
+		  template.file_descriptor = sockfd;
+		  template.private_data = mif->if_index;
+		  mif->connection.index = unix_file_add (&unix_main, &template);
+		  memif_connect_master (vm, mif);
+
+		  /* grab another fd */
+		  sockfd = socket (AF_UNIX, SOCK_STREAM, 0);
+		  if (sockfd < 0)
+		    return 0;
+	        }
+	    }
+        }));
+      /* *INDENT-ON* */
     }
   return 0;
 }
@@ -354,24 +568,43 @@ static void
 close_memif_if (memif_main_t * mm, memif_if_t * mif)
 {
   vlib_main_t *vm = vlib_get_main ();
+  memif_listener_t *listener = 0;
+  memif_pending_connection_t *pending_connection = 0;
 
   memif_disconnect (vm, mif);
 
-  if (mif->sock_file_index != ~0)
+  if (mif->listener_index != (uword)~0)
     {
-      unix_file_del (&unix_main, unix_main.file_pool + mif->sock_file_index);
-      mif->sock_file_index = ~0;
-      mif->sock_fd = -1; /* closed in unix_file_del */
+      listener = pool_elt_at_index (mm->listeners, mif->listener_index);
+      if (--listener->usage_counter == 0)
+	{
+	  /* not used anymore -> remove the socket and pending connections */
+
+	  /* *INDENT-OFF* */
+	  pool_foreach (pending_connection, mm->pending_connections,
+	    ({
+	       if (pending_connection->listener_index == mif->listener_index)
+	         {
+		   memif_remove_pending_connection (pending_connection);
+	         }
+	     }));
+          /* *INDENT-ON* */
+
+	  unix_file_del (&unix_main,
+			 unix_main.file_pool + listener->socket.index);
+	  pool_put (mm->listeners, listener);
+	  unlink ((char *)mif->socket_filename);
+	}
     }
+
   if (mif->lockp != 0)
     {
       clib_mem_free ((void *) mif->lockp);
       mif->lockp = 0;
     }
 
-  mhash_unset (&mm->if_index_by_sock_file_name, mif->socket_file_name,
-	       &mif->if_index);
-  vec_free (mif->socket_file_name);
+  mhash_unset (&mm->if_index_by_key, &mif->key, &mif->if_index);
+  vec_free (mif->socket_filename);
   vec_free (mif->ring_data);
 
   memset (mif, 0, sizeof (*mif));
@@ -410,24 +643,25 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
 {
   memif_main_t *mm = &memif_main;
   vlib_thread_main_t *tm = vlib_get_thread_main ();
+  vnet_main_t *vnm = vnet_get_main ();
   memif_if_t *mif = 0;
   vnet_sw_interface_t *sw;
   clib_error_t *error = 0;
-  vnet_main_t *vnm = vnet_get_main ();
   int ret = 0;
   uword *p;
-  u8 hw_addr[6];
 
-  p = mhash_get (&mm->if_index_by_sock_file_name, args->socket_file_name);
+  p = mhash_get (&mm->if_index_by_key, &args->key);
   if (p)
     return VNET_API_ERROR_SUBIF_ALREADY_EXISTS;
 
   pool_get (mm->interfaces, mif);
   memset (mif, 0, sizeof (*mif));
+  mif->key = args->key;
   mif->if_index = mif - mm->interfaces;
-  mif->sock_fd = mif->conn_fd = -1;
-  mif->sock_file_index = mif->conn_file_index = ~0;
-  mif->hw_if_index = ~0;
+  mif->sw_if_index = mif->hw_if_index = mif->per_interface_next_index = ~0;
+  mif->listener_index = ~0;
+  mif->connection.index = ~0;
+  mif->connection.fd = -1;
 
   if (tm->n_vlib_mains > 1)
     {
@@ -435,20 +669,21 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
 					   CLIB_CACHE_LINE_BYTES);
       memset ((void *) mif->lockp, 0, CLIB_CACHE_LINE_BYTES);
     }
-  // TODO set mac manually
-  {
-    f64 now = vlib_time_now (vm);
-    u32 rnd;
-    rnd = (u32) (now * 1e6);
-    rnd = random_u32 (&rnd);
 
-    memcpy (hw_addr + 2, &rnd, sizeof (rnd));
-    hw_addr[0] = 2;
-    hw_addr[1] = 0xfe;
-  }
+  if (!args->hw_addr_set)
+    {
+      f64 now = vlib_time_now (vm);
+      u32 rnd;
+      rnd = (u32) (now * 1e6);
+      rnd = random_u32 (&rnd);
+
+      memcpy (args->hw_addr + 2, &rnd, sizeof (rnd));
+      args->hw_addr[0] = 2;
+      args->hw_addr[1] = 0xfe;
+    }
 
   error = ethernet_register_interface (vnm, memif_device_class.index,
-				       mif->if_index, hw_addr,
+				       mif->if_index, args->hw_addr,
 				       &mif->hw_if_index,
 				       memif_eth_flag_change);
 
@@ -461,76 +696,120 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
 
   sw = vnet_get_hw_sw_interface (vnm, mif->hw_if_index);
   mif->sw_if_index = sw->sw_if_index;
-  mif->per_interface_next_index = ~0;
 
-  // TODO Make configurable
   mif->log2_ring_size = args->log2_ring_size;
+  mif->buffer_size = args->buffer_size;
+
+  /* TODO: make configurable */
   mif->num_s2m_rings = 1;
   mif->num_m2s_rings = 1;
-  mif->buffer_size = 2048;
 
-  mhash_set_mem (&mm->if_index_by_sock_file_name, args->socket_file_name,
+  mhash_set_mem (&mm->if_index_by_key, &args->key,
 		 &mif->if_index, 0);
-  mif->socket_file_name = args->socket_file_name;
+
+  if (args->socket_filename != 0)
+    mif->socket_filename = args->socket_filename;
+  else
+    mif->socket_filename = vec_dup(mm->default_socket_filename);
 
   args->sw_if_index = mif->sw_if_index;
 
   if (args->is_master)
     {
-      int fd;
       struct sockaddr_un un = { 0 };
+      struct stat file_stat;
       int on = 1;
+      memif_listener_t *listener = 0;
 
-      if ((fd = socket (AF_UNIX, SOCK_STREAM, 0)) < 0)
+      if (stat ((char *) mif->socket_filename, &file_stat) == 0)
 	{
-	  ret = VNET_API_ERROR_SYSCALL_ERROR_2;
-	  goto error;
+	  if (!S_ISSOCK(file_stat.st_mode))
+	    {
+	      errno = ENOTSOCK;
+	      ret = VNET_API_ERROR_SYSCALL_ERROR_2;
+	      goto error;
+	    }
+	  /* *INDENT-OFF* */
+	  pool_foreach (listener, mm->listeners,
+	    ({
+	       if (listener->sock_dev == file_stat.st_dev &&
+		   listener->sock_ino == file_stat.st_ino)
+	         {
+		   /* attach memif to the existing listener */
+		   mif->listener_index = listener->index;
+		   ++listener->usage_counter;
+		   goto signal;
+	         }
+	     }));
+          /* *INDENT-ON* */
+          unlink ((char *)mif->socket_filename);
 	}
 
-      un.sun_family = AF_UNIX;
-      strncpy ((char *) un.sun_path, (char *) mif->socket_file_name,
-	       sizeof (un.sun_path) - 1);
+      pool_get (mm->listeners, listener);
+      memset (listener, 0, sizeof (*listener));
+      listener->socket.fd = -1;
+      listener->socket.index = ~0;
+      listener->index = listener - mm->listeners;
+      listener->usage_counter = 1;
 
-      // FIXME unsecure
-      unlink ((char *) mif->socket_file_name);
-
-      if (setsockopt (fd, SOL_SOCKET, SO_PASSCRED, &on, sizeof (on)) < 0)
+      if ((listener->socket.fd = socket (AF_UNIX, SOCK_STREAM, 0)) < 0)
 	{
 	  ret = VNET_API_ERROR_SYSCALL_ERROR_3;
 	  goto error;
 	}
-      if (bind (fd, (struct sockaddr *) &un, sizeof (un)) == -1)
+
+      un.sun_family = AF_UNIX;
+      strncpy ((char *) un.sun_path, (char *) mif->socket_filename,
+	       sizeof (un.sun_path) - 1);
+
+      if (setsockopt (listener->socket.fd, SOL_SOCKET, SO_PASSCRED,
+		      &on, sizeof (on)) < 0)
 	{
 	  ret = VNET_API_ERROR_SYSCALL_ERROR_4;
 	  goto error;
 	}
-
-      if (listen (fd, 1) == -1)
+      if (bind (listener->socket.fd, (struct sockaddr *) &un,
+		sizeof (un)) == -1)
 	{
 	  ret = VNET_API_ERROR_SYSCALL_ERROR_5;
 	  goto error;
 	}
+      if (listen (listener->socket.fd, 1) == -1)
+	{
+	  ret = VNET_API_ERROR_SYSCALL_ERROR_6;
+	  goto error;
+	}
+
+      if (stat ((char *)mif->socket_filename, &file_stat) == -1)
+	{
+	  ret = VNET_API_ERROR_SYSCALL_ERROR_7;
+	  goto error;
+	}
+
+      listener->sock_dev = file_stat.st_dev;
+      listener->sock_ino = file_stat.st_ino;
 
       unix_file_t template = { 0 };
       template.read_function = memif_fd_accept_ready;
-      template.file_descriptor = mif->sock_fd = fd;
-      template.private_data = mif->if_index;
-      mif->sock_file_index = unix_file_add (&unix_main, &template);
+      template.file_descriptor = listener->socket.fd;
+      template.private_data = listener->index;
+      listener->socket.index = unix_file_add (&unix_main, &template);
+
+      mif->listener_index = listener->index;
     }
   else
     {
       mif->flags |= MEMIF_IF_FLAG_IS_SLAVE;
-      mif->sock_fd = -1;
     }
 
 #if 0
-  /*use configured or generate random MAC address */
-  if (hw_addr_set)
-    memcpy (hw_addr, hw_addr_set, 6);
-  else if (tm->n_vlib_mains > 1 && pool_elts (mm->interfaces) == 1)
+  /* use configured or generate random MAC address */
+  if (!args->hw_addr_set &&
+      tm->n_vlib_mains > 1 && pool_elts (mm->interfaces) == 1)
     memif_worker_thread_enable ();
 #endif
 
+signal:
   vlib_process_signal_event (vm, memif_process_node.index, 0, 0);
   return 0;
 
@@ -545,26 +824,29 @@ error:
 }
 
 int
-memif_delete_if (vlib_main_t * vm, u8 * host_if_name)
+memif_delete_if (vlib_main_t * vm, u64 key)
 {
   vnet_main_t *vnm = vnet_get_main ();
   memif_main_t *mm = &memif_main;
   memif_if_t *mif;
   uword *p;
 
-  p = mhash_get (&mm->if_index_by_sock_file_name, host_if_name);
+  p = mhash_get (&mm->if_index_by_key, &key);
   if (p == NULL)
     {
-      clib_warning ("unix socket file %s does not exist", host_if_name);
+      clib_warning ("Memory interface with key %lu does not exist", key);
       return VNET_API_ERROR_SYSCALL_ERROR_1;
     }
   mif = pool_elt_at_index (mm->interfaces, p[0]);
+  mif->flags |= MEMIF_IF_FLAG_DELETING;
 
   /* bring down the interface */
   vnet_hw_interface_set_flags (vnm, mif->hw_if_index, 0);
+  vnet_sw_interface_set_flags (vnm, mif->sw_if_index, 0);
 
+  /* remove the interface */
   ethernet_delete_interface (vnm, mif->hw_if_index);
-
+  mif->hw_if_index = ~0;
   close_memif_if (mm, mif);
 
 #if 0
@@ -574,6 +856,32 @@ memif_delete_if (vlib_main_t * vm, u8 * host_if_name)
 
   return 0;
 }
+
+static clib_error_t *
+memif_config (vlib_main_t * vm, unformat_input_t * input)
+{
+  memif_main_t *mm = &memif_main;
+  u8 *default_socket_filename = 0;
+
+  while (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (input, "socket-filename %s", &default_socket_filename))
+	;
+      else
+	return clib_error_return (0, "unknown input '%U'",
+				  format_unformat_error, input);
+    }
+
+  if (default_socket_filename != 0)
+    {
+      vec_free(mm->default_socket_filename);
+      mm->default_socket_filename = default_socket_filename;
+    }
+
+  return 0;
+}
+
+VLIB_CONFIG_FUNCTION (memif_config, "memif");
 
 static clib_error_t *
 memif_init (vlib_main_t * vm)
@@ -598,10 +906,17 @@ memif_init (vlib_main_t * vm)
       mm->input_cpu_count = tr->count;
     }
 
-  mhash_init_vec_string (&mm->if_index_by_sock_file_name, sizeof (uword));
+  mhash_init (&mm->if_index_by_key, sizeof (uword), sizeof (u64));
 
   vec_validate_aligned (mm->rx_buffers, tm->n_vlib_mains - 1,
 			CLIB_CACHE_LINE_BYTES);
+
+  /* set default socket filename */
+  vec_validate (mm->default_socket_filename,
+		strlen (MEMIF_DEFAULT_SOCKET_FILENAME));
+  strncpy ((char *) mm->default_socket_filename,
+	   MEMIF_DEFAULT_SOCKET_FILENAME,
+	   vec_len (mm->default_socket_filename) - 1);
 
   return 0;
 }

--- a/src/plugins/memif/memif.c
+++ b/src/plugins/memif/memif.c
@@ -36,8 +36,8 @@
 
 memif_main_t memif_main;
 
-static clib_error_t * memif_fd_msg_ready (unix_file_t * uf);
-static clib_error_t * memif_fd_auth_ready (unix_file_t * uf);
+static clib_error_t *memif_fd_msg_ready (unix_file_t * uf);
+static clib_error_t *memif_fd_auth_ready (unix_file_t * uf);
 
 static u32
 memif_eth_flag_change (vnet_main_t * vnm, vnet_hw_interface_t * hi, u32 flags)
@@ -113,15 +113,15 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
 
   if (shm_fd == -1)
     {
-      clib_warning(
-	"Connection request is missing shared memory file descriptor");
+      clib_warning
+	("Connection request is missing shared memory file descriptor");
       retval = 1;
       goto response;
     }
 
   if (slave_cr == NULL)
     {
-      clib_warning("Connection request is missing slave credentials");
+      clib_warning ("Connection request is missing slave credentials");
       retval = 2;
       goto response;
     }
@@ -129,18 +129,17 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
   p = mhash_get (&mm->if_index_by_key, &req->key);
   if (!p)
     {
-      clib_warning("Connection request with unmatched key (%d)", req->key);
+      clib_warning ("Connection request with unmatched key (%d)", req->key);
       retval = 3;
       goto response;
     }
 
-  mif = vec_elt_at_index(mm->interfaces, *p);
+  mif = vec_elt_at_index (mm->interfaces, *p);
   if (mif->listener_index != pending_connection->listener_index)
     {
-      clib_warning(
-	"Connection request with non-matching listener (%d vs. %d)",
-	pending_connection->listener_index,
-	mif->listener_index);
+      clib_warning
+	("Connection request with non-matching listener (%d vs. %d)",
+	 pending_connection->listener_index, mif->listener_index);
       retval = 4;
       goto response;
     }
@@ -168,8 +167,8 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
 
   if (req->shared_mem_size < sizeof (memif_shm_t))
     {
-      clib_warning (
-	"Unexpectedly small shared memory segment received from slave.");
+      clib_warning
+	("Unexpectedly small shared memory segment received from slave.");
       retval = 8;
       goto response;
     }
@@ -178,16 +177,16 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
        mmap (NULL, req->shared_mem_size, PROT_READ | PROT_WRITE, MAP_SHARED,
 	     shm_fd, 0)) == MAP_FAILED)
     {
-      clib_unix_warning (
-	"Failed to map shared memory segment received from slave memif");
+      clib_unix_warning
+	("Failed to map shared memory segment received from slave memif");
       retval = 9;
       goto response;
     }
 
   if (((memif_shm_t *) shm)->cookie != 0xdeadbeef)
     {
-      clib_warning (
-	"Possibly corrupted shared memory segment received from slave memif");
+      clib_warning
+	("Possibly corrupted shared memory segment received from slave memif");
       munmap (shm, req->shared_mem_size);
       retval = 10;
       goto response;
@@ -224,13 +223,13 @@ memif_process_connect_resp (memif_if_t * mif, memif_msg_t * resp)
 
   if ((mif->flags & MEMIF_IF_FLAG_IS_SLAVE) == 0)
     {
-      clib_warning("Memif master does not accept connection responses");
+      clib_warning ("Memif master does not accept connection responses");
       return 0;
     }
 
   if ((mif->flags & MEMIF_IF_FLAG_CONNECTING) == 0)
     {
-      clib_warning("Unexpected connection response");
+      clib_warning ("Unexpected connection response");
       return 0;
     }
 
@@ -299,7 +298,7 @@ memif_process_incoming_msg (unix_file_t * uf, u8 is_pending_connection)
     {
       clib_warning ("Memif version mismatch");
       if (is_pending_connection)
-        memif_remove_pending_connection (pending_connection);
+	memif_remove_pending_connection (pending_connection);
       return 0;
     }
 
@@ -330,17 +329,16 @@ memif_process_incoming_msg (unix_file_t * uf, u8 is_pending_connection)
 	  cmsg = CMSG_NXTHDR (&mh, cmsg);
 	}
 
-      return memif_process_connect_req (pending_connection, &msg,
-					cr, shm_fd);
+      return memif_process_connect_req (pending_connection, &msg, cr, shm_fd);
 
     case MEMIF_MSG_TYPE_CONNECT_RESP:
       return memif_process_connect_resp (mif, &msg);
 
     case MEMIF_MSG_TYPE_DISCONNECT:
       if (is_pending_connection)
-        memif_remove_pending_connection (pending_connection);
+	memif_remove_pending_connection (pending_connection);
       else
-        memif_disconnect (vm, mif);
+	memif_disconnect (vm, mif);
       return 0;
 
     default:
@@ -348,19 +346,19 @@ memif_process_incoming_msg (unix_file_t * uf, u8 is_pending_connection)
       return 0;
     }
 
- return 0;
+  return 0;
 }
 
 static clib_error_t *
 memif_fd_auth_ready (unix_file_t * uf)
 {
-  return memif_process_incoming_msg (uf, 1 /* requires authentication */);
+  return memif_process_incoming_msg (uf, 1 /* requires authentication */ );
 }
 
 static clib_error_t *
 memif_fd_msg_ready (unix_file_t * uf)
 {
-  return memif_process_incoming_msg (uf, 0 /* already authenticated */);
+  return memif_process_incoming_msg (uf, 0 /* already authenticated */ );
 }
 
 static clib_error_t *
@@ -378,7 +376,7 @@ memif_fd_accept_ready (unix_file_t * uf)
 
   addr_len = sizeof (client);
   conn_fd = accept (uf->file_descriptor,
-		    (struct sockaddr *) &client, (socklen_t *) &addr_len);
+		    (struct sockaddr *) &client, (socklen_t *) & addr_len);
 
   if (conn_fd < 0)
     return clib_error_return_unix (0, "accept");
@@ -593,7 +591,7 @@ close_memif_if (memif_main_t * mm, memif_if_t * mif)
 	  unix_file_del (&unix_main,
 			 unix_main.file_pool + listener->socket.index);
 	  pool_put (mm->listeners, listener);
-	  unlink ((char *)mif->socket_filename);
+	  unlink ((char *) mif->socket_filename);
 	}
     }
 
@@ -704,13 +702,12 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
   mif->num_s2m_rings = 1;
   mif->num_m2s_rings = 1;
 
-  mhash_set_mem (&mm->if_index_by_key, &args->key,
-		 &mif->if_index, 0);
+  mhash_set_mem (&mm->if_index_by_key, &args->key, &mif->if_index, 0);
 
   if (args->socket_filename != 0)
     mif->socket_filename = args->socket_filename;
   else
-    mif->socket_filename = vec_dup(mm->default_socket_filename);
+    mif->socket_filename = vec_dup (mm->default_socket_filename);
 
   args->sw_if_index = mif->sw_if_index;
 
@@ -723,7 +720,7 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
 
       if (stat ((char *) mif->socket_filename, &file_stat) == 0)
 	{
-	  if (!S_ISSOCK(file_stat.st_mode))
+	  if (!S_ISSOCK (file_stat.st_mode))
 	    {
 	      errno = ENOTSOCK;
 	      ret = VNET_API_ERROR_SYSCALL_ERROR_2;
@@ -742,7 +739,7 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
 	         }
 	     }));
           /* *INDENT-ON* */
-          unlink ((char *)mif->socket_filename);
+	  unlink ((char *) mif->socket_filename);
 	}
 
       pool_get (mm->listeners, listener);
@@ -780,7 +777,7 @@ memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args)
 	  goto error;
 	}
 
-      if (stat ((char *)mif->socket_filename, &file_stat) == -1)
+      if (stat ((char *) mif->socket_filename, &file_stat) == -1)
 	{
 	  ret = VNET_API_ERROR_SYSCALL_ERROR_7;
 	  goto error;
@@ -874,7 +871,7 @@ memif_config (vlib_main_t * vm, unformat_input_t * input)
 
   if (default_socket_filename != 0)
     {
-      vec_free(mm->default_socket_filename);
+      vec_free (mm->default_socket_filename);
       mm->default_socket_filename = default_socket_filename;
     }
 

--- a/src/plugins/memif/memif.h
+++ b/src/plugins/memif/memif.h
@@ -17,14 +17,25 @@
 
 typedef struct
 {
+  u16 version;
+#define MEMIF_VERSION_MAJOR 0
+#define MEMIF_VERSION_MINOR 1
+#define MEMIF_VERSION ((MEMIF_VERSION_MAJOR << 8) | MEMIF_VERSION_MINOR)
   u8 type;
-#define MEMIF_MSG_TYPE_CONNECT 0
-#define MEMIF_MSG_TYPE_DISCONNECT 1
+#define MEMIF_MSG_TYPE_CONNECT_REQ  0
+#define MEMIF_MSG_TYPE_CONNECT_RESP 1
+#define MEMIF_MSG_TYPE_DISCONNECT   2
+
+  /* Connection-request parameters: */
+  u64 key;
   u8 log2_ring_size;
   u16 num_s2m_rings;
   u16 num_m2s_rings;
   u16 buffer_size;
   u32 shared_mem_size;
+
+  /* Connection-response parameters: */
+  u8 retval;
 } memif_msg_t;
 
 typedef struct __attribute__ ((packed))
@@ -62,24 +73,47 @@ typedef struct
 
 typedef struct
 {
+  int fd;
+  u32 index;
+} memif_file_t;
+
+typedef struct
+{
+  uword index;
+  dev_t sock_dev;
+  ino_t sock_ino;
+  memif_file_t socket;
+  u16 usage_counter;
+} memif_listener_t;
+
+typedef struct
+{
+  uword index;
+  memif_file_t connection;
+  uword listener_index;
+} memif_pending_connection_t;
+
+typedef struct
+{
   CLIB_CACHE_LINE_ALIGN_MARK (cacheline0);
   volatile u32 *lockp;
   u32 flags;
-#define MEMIF_IF_FLAG_ADMIN_UP (1 << 0)
-#define MEMIF_IF_FLAG_IS_SLAVE (1 << 1)
-#define MEMIF_IF_FLAG_CONNECTED (1 << 2)
+#define MEMIF_IF_FLAG_ADMIN_UP   (1 << 0)
+#define MEMIF_IF_FLAG_IS_SLAVE   (1 << 1)
+#define MEMIF_IF_FLAG_CONNECTING (1 << 2)
+#define MEMIF_IF_FLAG_CONNECTED  (1 << 3)
+#define MEMIF_IF_FLAG_DELETING   (1 << 4)
 
+  u64 key;
   uword if_index;
   u32 hw_if_index;
   u32 sw_if_index;
 
   u32 per_interface_next_index;
 
-  int sock_fd;
-  int conn_fd;
-  u32 sock_file_index;
-  u32 conn_file_index;
-  u8 *socket_file_name;
+  uword listener_index;
+  memif_file_t connection;
+  u8 *socket_filename;
 
   void **regions;
 
@@ -98,7 +132,14 @@ typedef struct
 typedef struct
 {
   CLIB_CACHE_LINE_ALIGN_MARK (cacheline0);
+  /* pool of all memory interfaces */
   memif_if_t *interfaces;
+
+  /* pool of all listeners */
+  memif_listener_t *listeners;
+
+  /* pool of pending connections */
+  memif_pending_connection_t *pending_connections;
 
   /* bitmap of pending rx interfaces */
   uword *pending_input_bitmap;
@@ -106,14 +147,18 @@ typedef struct
   /* rx buffer cache */
   u32 **rx_buffers;
 
-  /* hash of socket file names */
-  mhash_t if_index_by_sock_file_name;
+  /* hash of all registered keys */
+  mhash_t if_index_by_key;
 
   /* first cpu index */
   u32 input_cpu_first_index;
 
   /* total cpu count */
   u32 input_cpu_count;
+
+  /* configuration */
+  u8 *default_socket_filename;
+#define MEMIF_DEFAULT_SOCKET_FILENAME  "/var/vpp/memif.sock"
 } memif_main_t;
 
 extern memif_main_t memif_main;
@@ -122,16 +167,20 @@ extern vlib_node_registration_t memif_input_node;
 
 typedef struct
 {
-  u8 *socket_file_name;
+  u64 key;
+  u8 *socket_filename;
   u8 is_master;
   u8 log2_ring_size;
+  u16 buffer_size;
+  u8 hw_addr_set;
+  u8 hw_addr[6];
 
   /* return */
   u32 sw_if_index;
 } memif_create_if_args_t;
 
 int memif_create_if (vlib_main_t * vm, memif_create_if_args_t * args);
-int memif_delete_if (vlib_main_t * vm, u8 * host_if_name);
+int memif_delete_if (vlib_main_t * vm, u64 key);
 
 #ifndef __NR_memfd_create
 #if defined __x86_64__
@@ -160,6 +209,8 @@ typedef enum
 static_always_inline memif_ring_t *
 memif_get_ring (memif_if_t * mif, memif_ring_type_t type, u16 ring_num)
 {
+  if (vec_len (mif->regions) == 0)
+    return NULL;
   void *p = mif->regions[0];
   int ring_size =
     sizeof (memif_ring_t) +

--- a/src/plugins/memif/node.c
+++ b/src/plugins/memif/node.c
@@ -330,18 +330,17 @@ static uword
 memif_input_fn (vlib_main_t * vm, vlib_node_runtime_t * node,
 		vlib_frame_t * frame)
 {
-  int i;
   u32 n_rx_packets = 0;
   u32 cpu_index = os_get_cpu_number ();
   memif_main_t *nm = &memif_main;
   memif_if_t *mif;
 
-  for (i = 0; i < vec_len (nm->interfaces); i++)
-    {
-      mif = vec_elt_at_index (nm->interfaces, i);
+  /* *INDENT-OFF* */
+  pool_foreach (mif, nm->interfaces,
+    ({
       if (mif->flags & MEMIF_IF_FLAG_ADMIN_UP &&
 	  mif->flags & MEMIF_IF_FLAG_CONNECTED &&
-	  (i % nm->input_cpu_count) ==
+	  (mif->if_index % nm->input_cpu_count) ==
 	  (cpu_index - nm->input_cpu_first_index))
 	{
 	  if (mif->flags & MEMIF_IF_FLAG_IS_SLAVE)
@@ -353,7 +352,8 @@ memif_input_fn (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      memif_device_input_inline (vm, node, frame, mif,
 					 MEMIF_RING_S2M);
 	}
-    }
+    }));
+  /* *INDENT-ON* */
 
   return n_rx_packets;
 }


### PR DESCRIPTION
This pull request includes:
 - multiple memifs can share the same socket (through the so called listeners)
 - default socket filename can be defined in VPP startup configuration
 - memifs are paired/authenticated against each other using 64bit integers (keys)
 - memif version is part of the exchanged connection parameters
 - updated CLI to reflect the changes above
 - merged with memif interrupt mode implementation