### PR TITLE
Clean up error handling in memif plugin

### DIFF
--- a/src/plugins/memif/device.c
+++ b/src/plugins/memif/device.c
@@ -223,7 +223,7 @@ memif_interface_tx_inline (vlib_main_t * vm, vlib_node_runtime_t * node,
   if (mif->interrupt_line.fd > 0)
     {
       u8 b = rid;
-      write (mif->interrupt_line.fd, &b, sizeof (b));
+      CLIB_UNUSED (int r) = write (mif->interrupt_line.fd, &b, sizeof (b));
     }
 
   return frame->n_vectors;

--- a/src/plugins/memif/memif.c
+++ b/src/plugins/memif/memif.c
@@ -336,7 +336,7 @@ memif_conn_fd_read_ready (unix_file_t * uf)
       if (pending_connection == 0)
 	{
 	  DEBUG_LOG ("Received unexpected connection request");
-	  goto disconnect;
+	  return 0;
 	}
 
       /* Read anciliary data */
@@ -363,7 +363,7 @@ memif_conn_fd_read_ready (unix_file_t * uf)
       if (mif == 0)
 	{
 	  DEBUG_LOG ("Received unexpected connection response");
-	  goto disconnect;
+	  return 0;
 	}
       return memif_process_connect_resp (mif, &msg);
 

--- a/src/plugins/memif/memif.c
+++ b/src/plugins/memif/memif.c
@@ -34,6 +34,14 @@
 #include <vpp/app/version.h>
 #include <memif/memif.h>
 
+#define MEMIF_DEBUG 1
+
+#if MEMIF_DEBUG == 1
+  #define DEBUG_LOG(...) clib_warning(__VA_ARGS__)
+#else
+  #define DEBUG_LOG(...)
+#endif
+
 memif_main_t memif_main;
 
 static clib_error_t *memif_conn_fd_read_ready (unix_file_t * uf);
@@ -119,10 +127,11 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
   void *shm;
   uword *p;
   u8 retval = 0;
+  static clib_error_t *error = 0;
 
   if (shm_fd == -1)
     {
-      clib_warning
+      DEBUG_LOG
 	("Connection request is missing shared memory file descriptor");
       retval = 1;
       goto response;
@@ -130,7 +139,7 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
 
   if (int_fd == -1)
     {
-      clib_warning
+      DEBUG_LOG
 	("Connection request is missing interrupt line file descriptor");
       retval = 2;
       goto response;
@@ -138,7 +147,7 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
 
   if (slave_cr == NULL)
     {
-      clib_warning ("Connection request is missing slave credentials");
+      DEBUG_LOG ("Connection request is missing slave credentials");
       retval = 3;
       goto response;
     }
@@ -146,7 +155,7 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
   p = mhash_get (&mm->if_index_by_key, &req->key);
   if (!p)
     {
-      clib_warning ("Connection request with unmatched key (%d)", req->key);
+      DEBUG_LOG ("Connection request with unmatched key (%d)", req->key);
       retval = 4;
       goto response;
     }
@@ -154,7 +163,7 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
   mif = vec_elt_at_index (mm->interfaces, *p);
   if (mif->listener_index != pending_connection->listener_index)
     {
-      clib_warning
+      DEBUG_LOG
 	("Connection request with non-matching listener (%d vs. %d)",
 	 pending_connection->listener_index, mif->listener_index);
       retval = 5;
@@ -163,14 +172,14 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
 
   if (mif->flags & MEMIF_IF_FLAG_IS_SLAVE)
     {
-      clib_warning ("Memif slave does not accept connection requests");
+      DEBUG_LOG ("Memif slave does not accept connection requests");
       retval = 6;
       goto response;
     }
 
   if (mif->connection.fd != -1)
     {
-      clib_warning ("Memif %d is already connected", mif->key);
+      DEBUG_LOG ("Memif %d is already connected", mif->key);
       retval = 7;
       goto response;
     }
@@ -184,7 +193,7 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
 
   if (req->shared_mem_size < sizeof (memif_shm_t))
     {
-      clib_warning
+      DEBUG_LOG
 	("Unexpectedly small shared memory segment received from slave.");
       retval = 9;
       goto response;
@@ -194,15 +203,16 @@ memif_process_connect_req (memif_pending_connection_t * pending_connection,
        mmap (NULL, req->shared_mem_size, PROT_READ | PROT_WRITE, MAP_SHARED,
 	     shm_fd, 0)) == MAP_FAILED)
     {
-      clib_unix_warning
+      DEBUG_LOG
 	("Failed to map shared memory segment received from slave memif");
+      error = clib_error_return_unix (0, "mmap fd %d", shm_fd);
       retval = 10;
       goto response;
     }
 
   if (((memif_shm_t *) shm)->cookie != 0xdeadbeef)
     {
-      clib_warning
+      DEBUG_LOG
 	("Possibly corrupted shared memory segment received from slave memif");
       munmap (shm, req->shared_mem_size);
       retval = 11;
@@ -238,7 +248,7 @@ response:
   resp.type = MEMIF_MSG_TYPE_CONNECT_RESP;
   resp.retval = retval;
   send (fd, &resp, sizeof (resp), 0);
-  return 0;
+  return error;
 }
 
 static clib_error_t *
@@ -248,13 +258,13 @@ memif_process_connect_resp (memif_if_t * mif, memif_msg_t * resp)
 
   if ((mif->flags & MEMIF_IF_FLAG_IS_SLAVE) == 0)
     {
-      clib_warning ("Memif master does not accept connection responses");
+      DEBUG_LOG ("Memif master does not accept connection responses");
       return 0;
     }
 
   if ((mif->flags & MEMIF_IF_FLAG_CONNECTING) == 0)
     {
-      clib_warning ("Unexpected connection response");
+      DEBUG_LOG ("Unexpected connection response");
       return 0;
     }
 
@@ -282,6 +292,7 @@ memif_conn_fd_read_ready (unix_file_t * uf)
   memif_msg_t msg = { 0 };
   struct cmsghdr *cmsg;
   ssize_t size;
+  static clib_error_t *error = 0;
 
   iov[0].iov_base = (void *) &msg;
   iov[0].iov_len = sizeof (memif_msg_t);
@@ -301,26 +312,21 @@ memif_conn_fd_read_ready (unix_file_t * uf)
   size = recvmsg (uf->file_descriptor, &mh, 0);
   if (size != sizeof (memif_msg_t))
     {
-      if (0 == size)
+      if (size != 0)
 	{
-	  if (pending_connection)
-	    memif_remove_pending_connection (pending_connection);
-	  else
-	    memif_disconnect (vm, mif);
-	  return 0;
+	  DEBUG_LOG ("Malformed message received on fd %d",
+		     uf->file_descriptor);
+	  error = clib_error_return_unix (0, "recvmsg fd %d",
+					  uf->file_descriptor);
 	}
-      // TODO better error handling
-      clib_unix_error ("recvmsg");
-      return 0;
+      goto disconnect;
     }
 
   /* check version of the sender's memif plugin */
   if (msg.version != MEMIF_VERSION)
     {
-      clib_warning ("Memif version mismatch");
-      if (pending_connection)
-	memif_remove_pending_connection (pending_connection);
-      return 0;
+      DEBUG_LOG ("Memif version mismatch");
+      goto disconnect;
     }
 
   /* process the message based on its type */
@@ -329,8 +335,8 @@ memif_conn_fd_read_ready (unix_file_t * uf)
     case MEMIF_MSG_TYPE_CONNECT_REQ:
       if (pending_connection == 0)
 	{
-	  clib_warning ("Received unexpected connection request");
-	  return 0;
+	  DEBUG_LOG ("Received unexpected connection request");
+	  goto disconnect;
 	}
 
       /* Read anciliary data */
@@ -356,24 +362,27 @@ memif_conn_fd_read_ready (unix_file_t * uf)
     case MEMIF_MSG_TYPE_CONNECT_RESP:
       if (mif == 0)
 	{
-	  clib_warning ("Received unexpected connection response");
-	  return 0;
+	  DEBUG_LOG ("Received unexpected connection response");
+	  goto disconnect;
 	}
       return memif_process_connect_resp (mif, &msg);
 
     case MEMIF_MSG_TYPE_DISCONNECT:
-      if (pending_connection)
-	memif_remove_pending_connection (pending_connection);
-      else
-	memif_disconnect (vm, mif);
-      return 0;
+      goto disconnect;
 
     default:
-      clib_warning ("Received unknown message type");
-      return 0;
+      DEBUG_LOG ("Received unknown message type");
+      goto disconnect;
     }
 
   return 0;
+
+disconnect:
+  if (pending_connection)
+    memif_remove_pending_connection (pending_connection);
+  else
+    memif_disconnect (vm, mif);
+  return error;
 }
 
 static clib_error_t *
@@ -416,7 +425,7 @@ memif_conn_fd_accept_ready (unix_file_t * uf)
 		    (struct sockaddr *) &client, (socklen_t *) & addr_len);
 
   if (conn_fd < 0)
-    return clib_error_return_unix (0, "accept");
+    return clib_error_return_unix (0, "accept fd %d", uf->file_descriptor);
 
   pool_get (mm->pending_connections, pending_connection);
   pending_connection->index = pending_connection - mm->pending_connections;
@@ -432,20 +441,20 @@ memif_conn_fd_accept_ready (unix_file_t * uf)
   return 0;
 }
 
-static void
+static int
 memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
 {
   memif_msg_t msg;
   struct msghdr mh = { 0 };
   struct iovec iov[1];
   struct cmsghdr *cmsg;
-  int mfd;
-  int rv;
-  int fd_array[2];
+  int mfd = -1;
+  int rv = 0;
+  int fd_array[2] = { -1, -1 };
   char ctl[CMSG_SPACE (sizeof (fd_array))];
   memif_ring_t *ring = NULL;
   int i, j;
-  void *shm;
+  void *shm = 0;
   u64 buffer_offset;
   unix_file_t template = { 0 };
 
@@ -466,19 +475,34 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
     mif->buffer_size * (1 << mif->log2_ring_size) * (mif->num_s2m_rings +
 						     mif->num_m2s_rings);
 
-  // FIXME Error Handling
   if ((mfd = memfd_create ("shared mem", MFD_ALLOW_SEALING)) == -1)
-    clib_unix_error ("memfd_create");
+    {
+      DEBUG_LOG ("Failed to create anonymous file");
+      rv = VNET_API_ERROR_SYSCALL_ERROR_1;
+      goto error;
+    }
 
   if ((fcntl (mfd, F_ADD_SEALS, F_SEAL_SHRINK)) == -1)
-    clib_unix_error ("fcntl");
+    {
+      DEBUG_LOG ("Failed to seal an anonymous file off from truncating");
+      rv = VNET_API_ERROR_SYSCALL_ERROR_2;
+      goto error;
+    }
 
   if ((ftruncate (mfd, msg.shared_mem_size)) == -1)
-    clib_unix_error ("ftruncate");
+    {
+      DEBUG_LOG ("Failed to extend the size of an anonymous file");
+      rv = VNET_API_ERROR_SYSCALL_ERROR_3;
+      goto error;
+    }
 
   if ((shm = mmap (NULL, msg.shared_mem_size, PROT_READ | PROT_WRITE,
 		   MAP_SHARED, mfd, 0)) == MAP_FAILED)
-    clib_unix_error ("mmap");
+    {
+      DEBUG_LOG ("Failed to map anonymous file into memory");
+      rv = VNET_API_ERROR_SYSCALL_ERROR_4;
+      goto error;
+    }
 
   vec_add1 (mif->regions, shm);
   ((memif_shm_t *) mif->regions[0])->cookie = 0xdeadbeef;
@@ -515,8 +539,12 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
   mh.msg_iovlen = 1;
 
   /* create interrupt socket */
-  if (socketpair(AF_UNIX, SOCK_STREAM, 0, fd_array) < 0)
-    clib_unix_error ("socketpair");
+  if (socketpair (AF_UNIX, SOCK_STREAM, 0, fd_array) < 0)
+    {
+      DEBUG_LOG ("Failed to create a pair of connected sockets");
+      rv = VNET_API_ERROR_SYSCALL_ERROR_5;
+      goto error;
+    }
 
   mif->interrupt_line.fd = fd_array[0];
   template.read_function = memif_int_fd_read_ready;
@@ -537,10 +565,28 @@ memif_connect_master (vlib_main_t * vm, memif_if_t * mif)
   mif->flags |= MEMIF_IF_FLAG_CONNECTING;
   rv = sendmsg (mif->connection.fd, &mh, 0);
   if (rv < 0)
-    clib_unix_warning ("sendmsg");
+    {
+      DEBUG_LOG ("Failed to send memif connection request");
+      rv = VNET_API_ERROR_SYSCALL_ERROR_6;
+      goto error;
+    }
 
+  /* No need to keep the descriptor open,
+   * mmap creates an extra reference to the underlying file */
+  close (mfd);
+  mfd = -1;
   /* This FD is given to peer, so we can close it */
   close (fd_array[1]);
+  fd_array[1] = -1;
+  return 0;
+
+error:
+  if (mfd > -1)
+    close (mfd);
+  if (fd_array[1] > -1)
+    close (fd_array[1]);
+  memif_disconnect (vm, mif);
+  return rv;
 }
 
 static uword
@@ -622,7 +668,10 @@ memif_process (vlib_main_t * vm, vlib_node_runtime_t * rt, vlib_frame_t * f)
 		  /* grab another fd */
 		  sockfd = socket (AF_UNIX, SOCK_STREAM, 0);
 		  if (sockfd < 0)
-		    return 0;
+		    {
+		      clib_unix_warning ("socket");
+		      return 0;
+		    }
 	        }
 	    }
         }));
@@ -641,7 +690,7 @@ VLIB_REGISTER_NODE (memif_process_node,static) = {
 /* *INDENT-ON* */
 
 static void
-close_memif_if (memif_main_t * mm, memif_if_t * mif)
+memif_close_if (memif_main_t * mm, memif_if_t * mif)
 {
   vlib_main_t *vm = vlib_get_main ();
   memif_listener_t *listener = 0;
@@ -898,7 +947,7 @@ error:
       ethernet_delete_interface (vnm, mif->hw_if_index);
       mif->hw_if_index = ~0;
     }
-  close_memif_if (mm, mif);
+  memif_close_if (mm, mif);
   return ret;
 }
 
@@ -926,7 +975,7 @@ memif_delete_if (vlib_main_t * vm, u64 key)
   /* remove the interface */
   ethernet_delete_interface (vnm, mif->hw_if_index);
   mif->hw_if_index = ~0;
-  close_memif_if (mm, mif);
+  memif_close_if (mm, mif);
 
   if (pool_elts (mm->interfaces) == 0)
     {

--- a/src/plugins/memif/memif.c
+++ b/src/plugins/memif/memif.c
@@ -663,7 +663,7 @@ memif_process (vlib_main_t * vm, vlib_node_runtime_t * rt, vlib_frame_t * f)
 		  sockfd = socket (AF_UNIX, SOCK_STREAM, 0);
 		  if (sockfd < 0)
 		    {
-		      DEBUG_UNIX_LOG ("socket");
+		      DEBUG_UNIX_LOG ("socket AF_UNIX");
 		      return 0;
 		    }
 	        }


### PR DESCRIPTION
- cleaned up and unified error handling in the memif plugin
- close_memif_if renamed to memif_close_if as it was the only function not prefixed with "memif_"
- explicitly ignored return value from _write_