### PR TITLE
fix-work-around version extraction from git tags

### DIFF
--- a/src/scripts/version
+++ b/src/scripts/version
@@ -17,7 +17,11 @@ else
     fi
 fi
 
-TAG=$(echo ${vstring} | cut -d- -f1 | sed -e 's/^v//')
+if [[ -z $vstring ]]; then
+	TAG="0.0-unknown"
+else
+	TAG=$(echo ${vstring} | cut -d- -f1 | sed -e 's/^v//')
+fi
 ADD=$(echo ${vstring} | cut -s -d- -f2)
 
 git rev-parse 2> /dev/null
@@ -26,6 +30,11 @@ if [ $? == 0 ]; then
 else
     CMT=$(echo ${vstring} | cut -s -d- -f3,4)
 fi
+
+if [[ -z $CMT ]]; then
+	CMT="0.0-unknown"
+fi
+
 CMTR=$(echo $CMT | sed 's/-/_/')
 
 if [ -n "${BUILD_NUMBER}" ]; then


### PR DESCRIPTION
debpkg fails to create deb packages due faulty version extraction script
by depositing "-release" as version number and not acceptable by debpkg
due to it must begin with a number but letter character.
reason: master branch normally expected to be in buildable condition so
the fix is only for github master branch currently failing
to produce deb packages on default script suggested in the manual.

./build-root/vagrant/build.sh

consequance: normally master branch expected to have version tag
current fix will produce 0.0-uknown version number.