### PR TITLE
tapv2: Sporadic SIGABRT in ethernet_input [VPP-1183]

### DIFF
--- a/src/vnet/devices/tap/cli.c
+++ b/src/vnet/devices/tap/cli.c
@@ -258,8 +258,9 @@ tap_show_command_fn (vlib_main_t * vm, unformat_input_t * input,
 	// RX = 0, TX = 1
 	vring = vec_elt_at_index (vif->vrings, i);
 	vlib_cli_output (vm, "  Virtqueue (%s)", (i & 1) ? "TX" : "RX");
-	vlib_cli_output (vm, "    qsz %d, last_used_idx %d, desc_in_use %d",
-			 vring->size, vring->last_used_idx,
+	vlib_cli_output (vm,
+			 "    qsz %d, last_used_idx %d, desc_next %d, desc_in_use %d",
+			 vring->size, vring->last_used_idx, vring->desc_next,
 			 vring->desc_in_use);
 	vlib_cli_output (vm,
 			 "    avail.flags 0x%x avail.idx %d used.flags 0x%x used.idx %d",

--- a/src/vnet/devices/virtio/virtio.c
+++ b/src/vnet/devices/virtio/virtio.c
@@ -138,13 +138,13 @@ static_always_inline void
 virtio_free_rx_buffers (vlib_main_t * vm, virtio_vring_t * vring)
 {
   u16 used = vring->desc_in_use;
-  u16 next = vring->desc_next;
+  u16 last = vring->last_used_idx;
   u16 mask = vring->size - 1;
 
   while (used)
     {
-      vlib_buffer_free (vm, &vring->buffers[next], 1);
-      next = (next + 1) & mask;
+      vlib_buffer_free (vm, &vring->buffers[last & mask], 1);
+      last++;
       used--;
     }
 }


### PR DESCRIPTION
virtio_free_rx_buffers uses the wrong slot in the vring to get
the buffer index. It uses desc_next. It should be last_used_idx
which is the slot number for the first valid descriptor.

Change-Id: I6b62b794f06869fbffffce45430b8b2e37b1266c
Signed-off-by: Steven <sluong@cisco.com>