### PR TITLE
Fix format for the dst address in the STN trace

### DIFF
--- a/src/plugins/stn/stn.c
+++ b/src/plugins/stn/stn.c
@@ -63,8 +63,8 @@ format_stn_ip46_punt_trace (u8 * s, va_list * args, u8 is_ipv4)
   stn_ip46_punt_trace_t *t = va_arg (*args, stn_ip46_punt_trace_t *);
   u32 indent = format_get_indent (s);
 
-  format (s, "dst_address: %U\n", format_ip46_address,
-	  (ip46_address_t *)&t->kv.key, IP46_TYPE_ANY);
+  s = format (s, "dst_address: %U\n", format_ip46_address,
+	  (ip46_address_t *)t->kv.key, IP46_TYPE_ANY);
 
   if (t->kv.value == ~(0L))
     {


### PR DESCRIPTION
Output string 's' was not assigned the return value of format() for
the destination address, which, in case the underlying memory was moved
by the realloc, resulted in an invalid memory access by the subsequent
invocations of format().

Change-Id: I2b5dfd85db085c553ca5ec0b3257aeeb437c360a
Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>