### PR TITLE
Minimize bihash memory consumption

### DIFF
--- a/src/vppinfra/bihash_template.c
+++ b/src/vppinfra/bihash_template.c
@@ -282,6 +282,7 @@ int BV (clib_bihash_add_del)
       *v->kvp = *add_v;
       tmp_b.as_u64 = 0;
       tmp_b.offset = BV (clib_bihash_get_offset) (h, v);
+      tmp_b.refcnt = 1;
 
       b->as_u64 = tmp_b.as_u64;
       goto unlock;
@@ -321,6 +322,7 @@ int BV (clib_bihash_add_del)
 	      clib_memcpy (&(v->kvp[i]), add_v, sizeof (*add_v));
 	      CLIB_MEMORY_BARRIER ();
 	      b->as_u64 = h->saved_bucket.as_u64;
+	      b->refcnt++;
 	      goto unlock;
 	    }
 	}
@@ -334,8 +336,17 @@ int BV (clib_bihash_add_del)
 	    {
 	      memset (&(v->kvp[i]), 0xff, sizeof (*(add_v)));
 	      CLIB_MEMORY_BARRIER ();
-	      b->as_u64 = h->saved_bucket.as_u64;
-	      goto unlock;
+	      if (PREDICT_TRUE (h->saved_bucket.refcnt > 1))
+		{
+		  h->saved_bucket.refcnt -= 1;
+		  b->as_u64 = h->saved_bucket.as_u64;
+		  goto unlock;
+		}
+	      else
+		{
+		  tmp_b.as_u64 = 0;
+		  goto free_old_bucket;
+		}
 	    }
 	}
       rv = -3;
@@ -403,18 +414,18 @@ int BV (clib_bihash_add_del)
     goto try_resplit;
 
 expand_ok:
-  /* Keep track of the number of linear-scan buckets */
-  if (tmp_b.linear_search ^ mark_bucket_linear)
-    h->linear_buckets += (mark_bucket_linear == 1) ? 1 : -1;
-
   tmp_b.log2_pages = new_log2_pages;
   tmp_b.offset = BV (clib_bihash_get_offset) (h, save_new_v);
   tmp_b.linear_search = mark_bucket_linear;
+  tmp_b.refcnt = h->saved_bucket.refcnt + 1;
+
+free_old_bucket:
 
   CLIB_MEMORY_BARRIER ();
   b->as_u64 = tmp_b.as_u64;
   v = BV (clib_bihash_get_value) (h, h->saved_bucket.offset);
-  BV (value_free) (h, v, old_log2_pages);
+
+  BV (value_free) (h, v, h->saved_bucket.log2_pages);
 
 unlock:
   BV (clib_bihash_reset_cache) (b);
@@ -533,6 +544,8 @@ u8 *BV (format_bihash) (u8 * s, va_list * args)
   BVT (clib_bihash_value) * v;
   int i, j, k;
   u64 active_elements = 0;
+  u64 active_buckets = 0;
+  u64 linear_buckets = 0;
 
   s = format (s, "Hash table %s\n", h->name ? h->name : (u8 *) "(unnamed)");
 
@@ -545,6 +558,11 @@ u8 *BV (format_bihash) (u8 * s, va_list * args)
 	    s = format (s, "[%d]: empty\n", i);
 	  continue;
 	}
+
+      active_buckets++;
+
+      if (b->linear_search)
+	linear_buckets++;
 
       if (verbose)
 	{
@@ -576,11 +594,30 @@ u8 *BV (format_bihash) (u8 * s, va_list * args)
 	}
     }
 
-  s = format (s, "    %lld active elements\n", active_elements);
+  s = format (s, "    %lld active elements %lld active buckets\n",
+	      active_elements, active_buckets);
   s = format (s, "    %d free lists\n", vec_len (h->freelists));
-  s = format (s, "    %d linear search buckets\n", h->linear_buckets);
+
+  for (i = 0; i < vec_len (h->freelists); i++)
+    {
+      u32 nfree = 0;
+      BVT (clib_bihash_value) * free_elt;
+
+      free_elt = h->freelists[i];
+      while (free_elt)
+	{
+	  nfree++;
+	  free_elt = free_elt->next_free;
+	}
+
+      s = format (s, "       [len %d] %u free elts\n", 1 << i, nfree);
+    }
+
+  s = format (s, "    %lld linear search buckets\n", linear_buckets);
   s = format (s, "    %lld cache hits, %lld cache misses\n",
 	      h->cache_hits, h->cache_misses);
+  if (h->mheap)
+    s = format (s, "    mheap: %U", format_mheap, h->mheap, 0 /* verbose */ );
   return s;
 }
 

--- a/src/vppinfra/bihash_template.h
+++ b/src/vppinfra/bihash_template.h
@@ -61,11 +61,12 @@ typedef struct
       u32 offset;
       u8 linear_search;
       u8 log2_pages;
-      u16 cache_lru;
+      i16 refcnt;
     };
     u64 as_u64;
   };
 #if BIHASH_KVP_CACHE_SIZE > 0
+  u16 cache_lru;
     BVT (clib_bihash_kv) cache[BIHASH_KVP_CACHE_SIZE];
 #endif
 } BVT (clib_bihash_bucket);
@@ -82,7 +83,6 @@ typedef struct
 
   u32 nbuckets;
   u32 log2_nbuckets;
-  u32 linear_buckets;
   u8 *name;
 
   u64 cache_hits;
@@ -97,12 +97,10 @@ typedef struct
 static inline void
 BV (clib_bihash_update_lru) (BVT (clib_bihash_bucket) * b, u8 slot)
 {
+#if BIHASH_KVP_CACHE_SIZE > 1
   u16 value, tmp, mask;
   u8 found_lru_pos;
   u16 save_hi;
-
-  if (BIHASH_KVP_CACHE_SIZE < 2)
-    return;
 
   ASSERT (slot < BIHASH_KVP_CACHE_SIZE);
 
@@ -149,6 +147,7 @@ BV (clib_bihash_update_lru) (BVT (clib_bihash_bucket) * b, u8 slot)
   value = save_hi | (tmp << 3) | slot;
 
   b->cache_lru = value;
+#endif
 }
 
 void
@@ -192,28 +191,29 @@ static inline void BV (clib_bihash_reset_cache) (BVT (clib_bihash_bucket) * b)
 
 static inline int BV (clib_bihash_lock_bucket) (BVT (clib_bihash_bucket) * b)
 {
-  BVT (clib_bihash_bucket) tmp_b;
-  u64 rv;
+#if BIHASH_KVP_CACHE_SIZE > 0
+  u16 cache_lru_bit;
+  u16 rv;
 
-  tmp_b.as_u64 = 0;
-  tmp_b.cache_lru = 1 << 15;
+  cache_lru_bit = 1 << 15;
 
-  rv = __sync_fetch_and_or (&b->as_u64, tmp_b.as_u64);
-  tmp_b.as_u64 = rv;
+  rv = __sync_fetch_and_or (&b->cache_lru, cache_lru_bit);
   /* Was already locked? */
-  if (tmp_b.cache_lru & (1 << 15))
+  if (rv & (1 << 15))
     return 0;
+#endif
   return 1;
 }
 
 static inline void BV (clib_bihash_unlock_bucket)
   (BVT (clib_bihash_bucket) * b)
 {
-  BVT (clib_bihash_bucket) tmp_b;
+#if BIHASH_KVP_CACHE_SIZE > 0
+  u16 cache_lru;
 
-  tmp_b.as_u64 = b->as_u64;
-  tmp_b.cache_lru &= ~(1 << 15);
-  b->as_u64 = tmp_b.as_u64;
+  cache_lru = b->cache_lru & ~(1 << 15);
+  b->cache_lru = cache_lru;
+#endif
 }
 
 static inline void *BV (clib_bihash_get_value) (BVT (clib_bihash) * h,


### PR DESCRIPTION
Reference-count the number of entries in each bucket. If the reference
count goes to zero, free the backing store.

Add long-term churn-testing to test_bihash_template.c, thanks to
Andrew Yourtchenko for the initial implementation.

Change-Id: I4fbd9229cacfaba8027a85cbf87b74afdead6e39
Signed-off-by: Dave Barach <dave@barachs.net>