### PR TITLE
Periodic scan and probe of IP neighbors to maintain neighbor pools

### DIFF
--- a/src/vat/api_format.c
+++ b/src/vat/api_format.c
@@ -23,6 +23,7 @@
 #include <vlibapi/api.h>
 #include <vlibmemory/api.h>
 #include <vnet/ip/ip.h>
+#include <vnet/ip/ip_neighbor.h>
 #include <vnet/l2/l2_input.h>
 #include <vnet/l2tp/l2tp.h>
 #include <vnet/vxlan/vxlan.h>
@@ -5284,6 +5285,7 @@ _(l2_interface_efp_filter_reply)                        \
 _(l2_interface_vlan_tag_rewrite_reply)                  \
 _(modify_vhost_user_if_reply)                           \
 _(delete_vhost_user_if_reply)                           \
+_(ip_scan_neighbor_enable_disable_reply)                \
 _(want_ip4_arp_events_reply)                            \
 _(want_ip6_nd_events_reply)                             \
 _(want_l2_macs_events_reply)                            \
@@ -5522,6 +5524,7 @@ _(L2_FIB_TABLE_DETAILS, l2_fib_table_details)				\
 _(VXLAN_GPE_ADD_DEL_TUNNEL_REPLY, vxlan_gpe_add_del_tunnel_reply)	    \
 _(VXLAN_GPE_TUNNEL_DETAILS, vxlan_gpe_tunnel_details)                   \
 _(INTERFACE_NAME_RENUMBER_REPLY, interface_name_renumber_reply)		\
+_(IP_SCAN_NEIGHBOR_ENABLE_DISABLE_REPLY, ip_scan_neighbor_enable_disable_reply) \
 _(WANT_IP4_ARP_EVENTS_REPLY, want_ip4_arp_events_reply)			\
 _(IP4_ARP_EVENT, ip4_arp_event)                                         \
 _(WANT_IP6_ND_EVENTS_REPLY, want_ip6_nd_events_reply)			\
@@ -14003,6 +14006,78 @@ api_interface_name_renumber (vat_main_t * vam)
 
   mp->sw_if_index = ntohl (sw_if_index);
   mp->new_show_dev_instance = ntohl (new_show_dev_instance);
+
+  S (mp);
+  W (ret);
+  return ret;
+}
+
+static int
+api_ip_scan_neighbor_enable_disable (vat_main_t * vam)
+{
+  unformat_input_t *i = vam->input;
+  vl_api_ip_scan_neighbor_enable_disable_t *mp;
+  u8 mode = IP_SCAN_V46_NEIGHBORS;
+  u32 interval = 0, time = 0, update = 0, delay = 0, stale = 0;
+  int ret;
+
+  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (i, "ip4"))
+	mode = IP_SCAN_V4_NEIGHBORS;
+      else if (unformat (i, "ip6"))
+	mode = IP_SCAN_V6_NEIGHBORS;
+      if (unformat (i, "both"))
+	mode = IP_SCAN_V46_NEIGHBORS;
+      else if (unformat (i, "disable"))
+	mode = IP_SCAN_DISABLED;
+      else if (unformat (i, "interval %d", &interval))
+	;
+      else if (unformat (i, "max-time %d", &time))
+	;
+      else if (unformat (i, "max-update %d", &update))
+	;
+      else if (unformat (i, "delay %d", &delay))
+	;
+      else if (unformat (i, "stale %d", &stale))
+	;
+      else
+	break;
+    }
+
+  if (interval > 255)
+    {
+      errmsg ("interval cannot exceed 255 minutes.");
+      return -99;
+    }
+  if (time > 255)
+    {
+      errmsg ("max-time cannot exceed 255 usec.");
+      return -99;
+    }
+  if (update > 255)
+    {
+      errmsg ("max-update cannot exceed 255.");
+      return -99;
+    }
+  if (delay > 255)
+    {
+      errmsg ("delay cannot exceed 255 msec.");
+      return -99;
+    }
+  if (stale > 255)
+    {
+      errmsg ("stale cannot exceed 255 minutes.");
+      return -99;
+    }
+
+  M (IP_SCAN_NEIGHBOR_ENABLE_DISABLE, mp);
+  mp->mode = mode;
+  mp->scan_interval = interval;
+  mp->max_proc_time = time;
+  mp->max_update = update;
+  mp->scan_int_delay = delay;
+  mp->stale_threshold = stale;
 
   S (mp);
   W (ret);
@@ -22842,6 +22917,8 @@ _(interface_name_renumber,                                              \
 _(input_acl_set_interface,                                              \
   "<intfc> | sw_if_index <nn> [ip4-table <nn>] [ip6-table <nn>]\n"      \
   "  [l2-table <nn>] [del]")                                            \
+_(ip_scan_neighbor_enable_disable, "[ip4|ip6|both|disable] [interval <n-min>]\n" \
+  "  [max-time <n-usec>] [max-update <n>] [delay <n-msec>] [stale <n-min>]") \
 _(want_ip4_arp_events, "address <ip4-address> [del]")                   \
 _(want_ip6_nd_events, "address <ip6-address> [del]")                    \
 _(want_l2_macs_events, "[disable] [learn-limit <n>] [scan-delay <n>] [max-entries <n>]") \

--- a/src/vnet.am
+++ b/src/vnet.am
@@ -350,6 +350,7 @@ libvnet_la_SOURCES +=				\
  vnet/ip/ip6_input.c				\
  vnet/ip/ip6_neighbor.c				\
  vnet/ip/ip6_pg.c				\
+ vnet/ip/ip_neighbor.c				\
  vnet/ip/ip_api.c				\
  vnet/ip/ip_checksum.c				\
  vnet/ip/ip_frag.c				\
@@ -381,6 +382,7 @@ nobase_include_HEADERS +=			\
  vnet/ip/ip.h					\
  vnet/ip/ip_packet.h				\
  vnet/ip/ip_source_and_port_range_check.h	\
+ vnet/ip/ip_neighbor.h				\
  vnet/ip/lookup.h				\
  vnet/ip/ports.def				\
  vnet/ip/protocols.def				\

--- a/src/vnet/ethernet/arp.c
+++ b/src/vnet/ethernet/arp.c
@@ -269,7 +269,7 @@ format_ethernet_arp_ip4_entry (u8 * s, va_list * va)
     flags = format (flags, "N");
 
   s = format (s, "%=12U%=16U%=6s%=20U%U",
-	      format_vlib_cpu_time, vnm->vlib_main, e->cpu_time_last_updated,
+	      format_vlib_time, vnm->vlib_main, e->time_last_updated,
 	      format_ip4_address, &e->ip4_address,
 	      flags ? (char *) flags : "",
 	      format_ethernet_address, e->ethernet_address,
@@ -615,14 +615,17 @@ vnet_arp_set_ip4_over_ethernet_internal (vnet_main_t * vnm,
        */
       if (0 == memcmp (e->ethernet_address,
 		       a->ethernet, sizeof (e->ethernet_address)))
-	goto check_customers;
+	{
+	  e->time_last_updated = vlib_time_now (vm);
+	  goto check_customers;
+	}
 
       /* Update time stamp and ethernet address. */
       clib_memcpy (e->ethernet_address, a->ethernet,
 		   sizeof (e->ethernet_address));
     }
 
-  e->cpu_time_last_updated = clib_cpu_time_now ();
+  e->time_last_updated = vlib_time_now (vm);
   if (is_static)
     e->flags |= ETHERNET_ARP_IP4_ENTRY_FLAG_STATIC;
   else
@@ -1296,6 +1299,13 @@ ip4_arp_entry_sort (void *a1, void *a2)
   if (!cmp)
     cmp = ip4_address_compare (&e1->ip4_address, &e2->ip4_address);
   return cmp;
+}
+
+ethernet_arp_ip4_entry_t *
+ip4_neighbors_pool (void)
+{
+  ethernet_arp_main_t *am = &ethernet_arp_main;
+  return am->ip4_entry_pool;
 }
 
 ethernet_arp_ip4_entry_t *

--- a/src/vnet/ethernet/arp_packet.h
+++ b/src/vnet/ethernet/arp_packet.h
@@ -156,7 +156,7 @@ typedef struct
 
   ethernet_arp_entry_flags_t flags;
 
-  u64 cpu_time_last_updated;
+  f64 time_last_updated;
 
   /**
    * The index of the adj-fib entry created
@@ -164,6 +164,7 @@ typedef struct
   fib_node_index_t fib_entry_index;
 } ethernet_arp_ip4_entry_t;
 
+ethernet_arp_ip4_entry_t *ip4_neighbors_pool (void);
 ethernet_arp_ip4_entry_t *ip4_neighbor_entries (u32 sw_if_index);
 u8 *format_ethernet_arp_ip4_entry (u8 * s, va_list * va);
 

--- a/src/vnet/ip/ip.api
+++ b/src/vnet/ip/ip.api
@@ -19,7 +19,7 @@
     called through a shared memory interface. 
 */
 
-vl_api_version 1.0.1
+vl_api_version 1.0.2
 
 /** \brief Add / del table request
            A table can be added multiple times, but need be deleted only once.
@@ -651,7 +651,32 @@ autoreply define ip_source_and_port_range_check_interface_add_del
   u32 udp_out_vrf_id;
 };
 
-/** \brief Register for ip4 arp resolution events
+/** \brief Enable/disable periodic IP neighbor scan
+    @param client_index - opaque cookie to identify the sender
+    @param context - sender context, to match reply w/ request
+    @param mode - 0: disable, 1: IPv4, 2: IPv6, 3: both IPv4/v6
+    @param scan_interval - neighbor scan interval in minutes, 0: default to 1
+    @param max_proc_time - max processing time per run in usec, 0: default to 20
+    @param max_update - max neighbor probe/delete per run, 0: default to 10
+    @param scan_int_delay - delay in msec to resume scan if exceed max proc
+                            time or update, 0: default to 1
+    @param stale_threshold - threshold in minutes for neighbor deletion, 
+                             0: default to 4*scan_interval
+*/
+autoreply define ip_scan_neighbor_enable_disable
+{
+  u32 client_index;
+  u32 context;
+  u8 mode;
+  u8 scan_interval;
+  u8 max_proc_time;
+  u8 max_update;
+  u8 scan_int_delay;
+  u8 stale_threshold;
+};
+
+/** \brief Register for IP4 ARP resolution event on receing ARP reply or
+           MAC/IP info from ARP requests in L2 BDs
     @param client_index - opaque cookie to identify the sender
     @param context - sender context, to match reply w/ request
     @param enable_disable - 1 => register for events, 0 => cancel registration

--- a/src/vnet/ip/ip6_neighbor.c
+++ b/src/vnet/ip/ip6_neighbor.c
@@ -286,8 +286,8 @@ format_ip6_neighbor_ip6_entry (u8 * s, va_list * va)
     flags = format (flags, "N");
 
   si = vnet_get_sw_interface (vnm, n->key.sw_if_index);
-  s = format (s, "%=12U%=20U%=6s%=20U%=40U",
-	      format_vlib_cpu_time, vm, n->cpu_time_last_updated,
+  s = format (s, "%=12U%=25U%=6s%=20U%=40U",
+	      format_vlib_time, vm, n->time_last_updated,
 	      format_ip6_address, &n->key.ip6_address,
 	      flags ? (char *) flags : "",
 	      format_ethernet_address, n->link_layer_address,
@@ -723,14 +723,17 @@ vnet_set_ip6_ethernet_neighbor (vlib_main_t * vm,
        */
       if (0 == memcmp (n->link_layer_address,
 		       link_layer_address, n_bytes_link_layer_address))
-	goto check_customers;
+	{
+	  n->time_last_updated = vlib_time_now (vm);
+	  goto check_customers;
+	}
 
       clib_memcpy (n->link_layer_address,
 		   link_layer_address, n_bytes_link_layer_address);
     }
 
   /* Update time stamp and flags. */
-  n->cpu_time_last_updated = clib_cpu_time_now ();
+  n->time_last_updated = vlib_time_now (vm);
   if (is_static)
     n->flags |= IP6_NEIGHBOR_FLAG_STATIC;
   else
@@ -871,6 +874,13 @@ ip6_neighbor_sort (void *a1, void *a2)
   if (!cmp)
     cmp = ip6_address_compare (&n1->key.ip6_address, &n2->key.ip6_address);
   return cmp;
+}
+
+ip6_neighbor_t *
+ip6_neighbors_pool (void)
+{
+  ip6_neighbor_main_t *nm = &ip6_neighbor_main;
+  return nm->neighbor_pool;
 }
 
 ip6_neighbor_t *

--- a/src/vnet/ip/ip6_neighbor.h
+++ b/src/vnet/ip/ip6_neighbor.h
@@ -40,9 +40,11 @@ typedef struct
   ip6_neighbor_key_t key;
   u8 link_layer_address[8];
   ip6_neighbor_flags_t flags;
-  u64 cpu_time_last_updated;
+  f64 time_last_updated;
   fib_node_index_t fib_entry_index;
 } ip6_neighbor_t;
+
+extern ip6_neighbor_t *ip6_neighbors_pool (void);
 
 extern ip6_neighbor_t *ip6_neighbors_entries (u32 sw_if_index);
 

--- a/src/vnet/ip/ip_api.c
+++ b/src/vnet/ip/ip_api.c
@@ -25,6 +25,7 @@
 #include <vnet/api_errno.h>
 #include <vnet/ethernet/ethernet.h>
 #include <vnet/ip/ip.h>
+#include <vnet/ip/ip_neighbor.h>
 #include <vnet/ip/ip6_neighbor.h>
 #include <vnet/fib/fib_table.h>
 #include <vnet/fib/fib_api.h>
@@ -74,6 +75,7 @@ _(IP_ADDRESS_DUMP, ip_address_dump)                                     \
 _(IP_DUMP, ip_dump)                                                     \
 _(IP_NEIGHBOR_ADD_DEL, ip_neighbor_add_del)                             \
 _(SET_ARP_NEIGHBOR_LIMIT, set_arp_neighbor_limit)			\
+_(IP_SCAN_NEIGHBOR_ENABLE_DISABLE, ip_scan_neighbor_enable_disable)     \
 _(WANT_IP4_ARP_EVENTS, want_ip4_arp_events)                             \
 _(WANT_IP6_ND_EVENTS, want_ip6_nd_events)                               \
 _(PROXY_ARP_ADD_DEL, proxy_arp_add_del)                                 \
@@ -2654,6 +2656,25 @@ static void
   BAD_SW_IF_INDEX_LABEL;
 
   REPLY_MACRO (VL_API_PROXY_ARP_INTFC_ENABLE_DISABLE_REPLY);
+}
+
+static void
+  vl_api_ip_scan_neighbor_enable_disable_t_handler
+  (vl_api_ip_scan_neighbor_enable_disable_t * mp)
+{
+  int rv = 0;
+  vl_api_ip_scan_neighbor_enable_disable_reply_t *rmp;
+  ip_neighbor_scan_arg_t arg;
+
+  arg.mode = mp->mode;
+  arg.scan_interval = mp->scan_interval;
+  arg.max_proc_time = mp->max_proc_time;
+  arg.max_update = mp->max_update;
+  arg.scan_int_delay = mp->scan_int_delay;
+  arg.stale_threshold = mp->stale_threshold;
+  ip_neighbor_scan_enable_disable (&arg);
+
+  REPLY_MACRO (VL_API_IP_SCAN_NEIGHBOR_ENABLE_DISABLE_REPLY);
 }
 
 static int

--- a/src/vnet/ip/ip_neighbor.c
+++ b/src/vnet/ip/ip_neighbor.c
@@ -1,0 +1,408 @@
+/*
+ * src/vnet/ip/ip_neighboor.c: ip neighbor generic handling
+ *
+ * Copyright (c) 2018 Cisco and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vnet/vnet.h>
+#include <vnet/ip/ip.h>
+#include <vnet/ip/ip6_neighbor.h>
+#include <vnet/ip/ip_neighbor.h>
+#include <vnet/ethernet/arp_packet.h>
+
+/*
+ * IP neighbor scan parameter defaults are as follows:
+ *   - Scan interval                       : 60 sec
+ *   - Max processing allowed per run      : 20 usec
+ *   - Max probe/delete operations per run : 10
+ *   - Scan interrupt delay to resume scan : 1 msec
+ *   - Neighbor stale threashold           : 4 x scan-interval
+ */
+#define IP_NEIGHBOR_DEF_SCAN_INTERVAL (60.0)
+#define IP_NEIGHBOR_DEF_MAX_PROC_TIME (20e-6)
+#define IP_NEIGHBOR_DEF_SCAN_INT_DELAY (1e-3)
+#define IP_NEIGHBOR_DEF_STALE (4*IP_NEIGHBOR_DEF_SCAN_INTERVAL)
+#define IP_NEIGHBOR_DEF_MAX_UPDATE 10
+
+typedef struct
+{
+  f64 scan_interval;		/* Periodic scan interval */
+  f64 max_proc_time;		/* Max processing time allowed per run */
+  f64 scan_int_delay;		/* Scan interrupt delay to resume scan */
+  f64 stale_threshold;		/* IP neighbor stale threshod */
+  u8 max_update;		/* Max probe/delete actions allowed per run */
+  u8 mode;			/* IP neighbor scan mode */
+} ip_neighbor_scan_config_t;
+
+static ip_neighbor_scan_config_t ip_neighbor_scan_conf;
+
+void
+ip_neighbor_scan_enable_disable (ip_neighbor_scan_arg_t * arg)
+{
+  ip_neighbor_scan_config_t *cfg = &ip_neighbor_scan_conf;
+
+  cfg->mode = arg->mode;
+
+  if (arg->mode)
+    {
+      cfg->scan_interval = arg->scan_interval ?
+	arg->scan_interval * 1.0 : IP_NEIGHBOR_DEF_SCAN_INTERVAL;
+      cfg->max_proc_time = arg->max_proc_time ?
+	arg->max_proc_time * 1e-6 : IP_NEIGHBOR_DEF_MAX_PROC_TIME;
+      cfg->scan_int_delay = arg->scan_int_delay ?
+	arg->scan_int_delay * 1e-3 : IP_NEIGHBOR_DEF_SCAN_INT_DELAY;
+      cfg->stale_threshold = arg->stale_threshold ?
+	arg->stale_threshold * 1.0 : cfg->scan_interval * 4;
+      cfg->max_update = arg->max_update ?
+	cfg->max_update : IP_NEIGHBOR_DEF_MAX_UPDATE;
+    }
+  else
+    cfg->scan_interval = IP_NEIGHBOR_DEF_SCAN_INTERVAL;
+}
+
+static_always_inline u32
+ip_neighbor_scan (vlib_main_t * vm, f64 start_time, u32 start_idx,
+		  u8 is_ip6, u8 delete_stale, u8 * update_count)
+{
+  vnet_main_t *vnm = vnet_get_main ();
+  ip_neighbor_scan_config_t *cfg = &ip_neighbor_scan_conf;
+  ethernet_arp_ip4_entry_t *np4 = ip4_neighbors_pool ();
+  ip6_neighbor_t *np6 = ip6_neighbors_pool ();
+  ethernet_arp_ip4_entry_t *n4;
+  ip6_neighbor_t *n6;
+  u32 curr_idx = start_idx;
+  u32 loop_count = 0;
+  f64 delta, update_time;
+
+  if (!is_ip6)
+    {
+      if (pool_is_free_index (np4, start_idx))
+	curr_idx = pool_next_index (np4, start_idx);
+    }
+  else
+    {
+      if (pool_is_free_index (np6, start_idx))
+	curr_idx = pool_next_index (np6, start_idx);
+    }
+
+  while (curr_idx != ~0)
+    {
+      /* allow no more than 10 neighbor updates or 20 usec of scan */
+      if ((update_count[0] >= cfg->max_update) ||
+	  (((loop_count % 100) == 0) &&
+	   ((vlib_time_now (vm) - start_time) > cfg->max_proc_time)))
+	break;
+
+      if (!is_ip6)
+	{
+	  n4 = pool_elt_at_index (np4, curr_idx);
+	  if (n4->flags & ETHERNET_ARP_IP4_ENTRY_FLAG_STATIC)
+	    goto next_neighbor;
+	  update_time = n4->time_last_updated;
+	}
+      else
+	{
+	  n6 = pool_elt_at_index (np6, curr_idx);
+	  if (n6->flags & IP6_NEIGHBOR_FLAG_STATIC)
+	    goto next_neighbor;
+	  update_time = n6->time_last_updated;
+	}
+
+      delta = start_time - update_time;
+      if (delete_stale && (delta >= cfg->stale_threshold))
+	{
+	  update_count[0]++;
+	  /* delete stale neighbor */
+	  if (!is_ip6)
+	    {
+	      ethernet_arp_ip4_over_ethernet_address_t delme;
+	      clib_memcpy (&delme.ethernet, n4->ethernet_address, 6);
+	      delme.ip4.as_u32 = n4->ip4_address.as_u32;
+	      vnet_arp_unset_ip4_over_ethernet (vnm, n4->sw_if_index, &delme);
+	    }
+	  else
+	    {
+	      vnet_unset_ip6_ethernet_neighbor
+		(vm, n6->key.sw_if_index, &n6->key.ip6_address,
+		 n6->link_layer_address, 6);
+	    }
+	}
+      else if (delta >= cfg->scan_interval)
+	{
+	  update_count[0]++;
+	  /* probe neighbor */
+	  if (!is_ip6)
+	    ip4_probe_neighbor (vm, &n4->ip4_address, n4->sw_if_index);
+	  else
+	    ip6_probe_neighbor (vm, &n6->key.ip6_address,
+				n6->key.sw_if_index);
+	}
+
+    next_neighbor:
+      loop_count++;
+
+      if (!is_ip6)
+	curr_idx = pool_next_index (np4, curr_idx);
+      else
+	curr_idx = pool_next_index (np6, curr_idx);
+    }
+
+  return curr_idx;
+}
+
+static uword
+neighbor_scan_process (vlib_main_t * vm,
+		       vlib_node_runtime_t * rt, vlib_frame_t * f)
+{
+  ip_neighbor_scan_config_t *cfg = &ip_neighbor_scan_conf;
+  f64 timeout = IP_NEIGHBOR_DEF_SCAN_INTERVAL;
+  f64 start, next_scan = CLIB_TIME_MAX;
+  u32 ip4_nidx = 0;		/* ip4 neighbor pool index */
+  u32 ip6_nidx = 0;		/* ip6 neighbor pool index */
+  uword *event_data = 0;
+  u8 purge4 = 0, purge6 = 0;	/* flags to purge stale entry during scan */
+  u8 update;
+
+  cfg->mode = IP_SCAN_DISABLED;
+  cfg->scan_interval = IP_NEIGHBOR_DEF_SCAN_INTERVAL;
+  cfg->scan_int_delay = IP_NEIGHBOR_DEF_SCAN_INTERVAL;
+
+  while (1)
+    {
+      vlib_process_wait_for_event_or_clock (vm, timeout);
+      vlib_process_get_events (vm, &event_data);
+      vec_reset_length (event_data);
+
+      start = vlib_time_now (vm);
+      update = 0;
+
+      if ((ip4_nidx == 0) && (ip6_nidx == 0))	/* starting a fresh scan */
+	next_scan = start + cfg->scan_interval;
+
+      if ((cfg->mode & IP_SCAN_V4_NEIGHBORS) == 0)
+	ip4_nidx = ~0;		/* disable ip4 neighbor scan */
+
+      if ((cfg->mode & IP_SCAN_V6_NEIGHBORS) == 0)
+	ip6_nidx = ~0;		/* disable ip6 neighbor scan */
+
+      if (ip4_nidx != ~0)	/* scan ip4 neighbors */
+	ip4_nidx = ip_neighbor_scan (vm, start, ip4_nidx, /* ip4 */ 0,
+				     purge4, &update);
+
+      if (ip6_nidx != ~0)	/* scan ip6 neighbors */
+	ip6_nidx = ip_neighbor_scan (vm, start, ip6_nidx, /* ip6 */ 1,
+				     purge6, &update);
+
+      if ((ip4_nidx == ~0) && (ip6_nidx == ~0))
+	{			/* scan complete */
+	  timeout = next_scan - vlib_time_now (vm);
+	  ip4_nidx = ip6_nidx = 0;
+	  purge4 = cfg->mode & IP_SCAN_V4_NEIGHBORS;
+	  purge6 = cfg->mode & IP_SCAN_V6_NEIGHBORS;
+	}
+      else			/* scan incomplete */
+	timeout = cfg->scan_int_delay;
+
+      if (timeout > cfg->scan_interval)
+	timeout = cfg->scan_interval;
+      else if (timeout < cfg->scan_int_delay)
+	timeout = cfg->scan_int_delay;
+
+    }
+  return 0;
+}
+
+/* *INDENT-OFF* */
+VLIB_REGISTER_NODE (neighbor_scan_process_node,static) = {
+  .function = neighbor_scan_process,
+  .type = VLIB_NODE_TYPE_PROCESS,
+  .name = "ip-neighbor-scan-process",
+};
+/* *INDENT-ON* */
+
+static clib_error_t *
+ip_neighbor_scan_cli (vlib_main_t * vm, unformat_input_t * input,
+		      vlib_cli_command_t * cmd)
+{
+  unformat_input_t _line_input, *line_input = &_line_input;
+  clib_error_t *error = 0;
+  u32 interval = 0, time = 0, update = 0, delay = 0, stale = 0;
+  ip_neighbor_scan_arg_t arg;
+
+  memset (&arg, 0, sizeof (arg));
+  arg.mode = IP_SCAN_V46_NEIGHBORS;
+
+  /* Get a line of input. */
+  if (!unformat_user (input, unformat_line_input, line_input))
+    {
+      ip_neighbor_scan_enable_disable (&arg);
+      return error;
+    }
+
+  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (line_input, "ip4"))
+	arg.mode = IP_SCAN_V4_NEIGHBORS;
+
+      else if (unformat (line_input, "ip6"))
+	arg.mode = IP_SCAN_V6_NEIGHBORS;
+
+      else if (unformat (line_input, "both"))
+	arg.mode = IP_SCAN_V46_NEIGHBORS;
+
+      else if (unformat (line_input, "disable"))
+	arg.mode = IP_SCAN_DISABLED;
+
+      else if (unformat (line_input, "interval %d", &interval))
+	arg.scan_interval = interval;
+
+      else if (unformat (line_input, "max-time %d", &time))
+	arg.max_proc_time = time;
+
+      else if (unformat (line_input, "max-update %d", &update))
+	arg.max_update = update;
+
+      else if (unformat (line_input, "delay %d", &delay))
+	arg.scan_int_delay = delay;
+
+      else if (unformat (line_input, "stale %d", &stale))
+	arg.stale_threshold = stale;
+
+      else
+	{
+	  error = clib_error_return (0, "unknown input '%U'",
+				     format_unformat_error, line_input);
+	  goto done;
+	}
+    }
+
+  if (interval > 255)
+    {
+      error = clib_error_return (0, "interval cannot exceed 255 minutes.");
+      goto done;
+    }
+  if (time > 255)
+    {
+      error = clib_error_return (0, "max-time cannot exceed 255 usec.");
+      goto done;
+    }
+  if (update > 255)
+    {
+      error = clib_error_return (0, "max-update cannot exceed 255.");
+      goto done;
+    }
+  if (delay > 255)
+    {
+      error = clib_error_return (0, "delay cannot exceed 255 msec.");
+      goto done;
+    }
+  if (stale > 255)
+    {
+      error = clib_error_return (0, "stale cannot exceed 255 minutes.");
+      goto done;
+    }
+
+  ip_neighbor_scan_enable_disable (&arg);
+
+done:
+  unformat_free (line_input);
+
+  return error;
+}
+
+/*?
+ * The '<em>ip scan-neighbor</em>' command can be used to enable and disable
+ * periodic IP neighbor scan and change various scan parameneters.
+ *
+ * @note The default parameters used for IP neighbor scan should work fine
+ * under normal conditions. They should not be changed from the default unless
+ * properly tested to work as desied.
+ *
+ * @cliexpar
+ * Example of enabling IP neighbor scan:
+ * @cliexcmd{ip neighbor-scan enable}
+?*/
+/* *INDENT-OFF* */
+VLIB_CLI_COMMAND (ip_scan_neighbor_command, static) = {
+  .path = "ip scan-neighbor",
+  .function = ip_neighbor_scan_cli,
+  .short_help = "ip scan-neighbor [ip4|ip6|both|disable] [interval <n-min>] [max-time <n-usec>] [max-update <n>] [delay <n-msec>] [stale <n-min>]",
+  .is_mp_safe = 1,
+};
+/* *INDENT-ON* */
+
+static u8 *
+format_ip_scan_mode (u8 * s, va_list * args)
+{
+  u8 mode = va_arg (*args, u32);
+  switch (mode)
+    {
+    case IP_SCAN_V4_NEIGHBORS:
+      return format (s, "IPv4");
+    case IP_SCAN_V6_NEIGHBORS:
+      return format (s, "IPv6");
+    case IP_SCAN_V46_NEIGHBORS:
+      return format (s, "IPv4 and IPv6");
+    }
+  return format (s, "unknown");
+}
+
+static clib_error_t *
+show_ip_neighbor_scan (vlib_main_t * vm, unformat_input_t * input,
+		       vlib_cli_command_t * cmd)
+{
+  ip_neighbor_scan_config_t *cfg = &ip_neighbor_scan_conf;
+
+  if (cfg->mode == 0)
+    vlib_cli_output (vm,
+		     "IP neighbor scan disabled - current time is %.4f sec",
+		     vlib_time_now (vm));
+  else
+    vlib_cli_output (vm, "IP neighbor scan enabled for %U neighbors - "
+		     "current time is %.4f sec\n   "
+		     "Full_scan_interval: %f min  "
+		     "Stale_purge_threshod: %f min\n   "
+		     "Max_process_time: %f usec  Max_updates %d  "
+		     "Delay_to_resume_after_max_limit: %f msec",
+		     format_ip_scan_mode, cfg->mode,
+		     vlib_time_now (vm), cfg->scan_interval / 60.0,
+		     cfg->stale_threshold / 60.0, cfg->max_proc_time / 1e-6,
+		     cfg->max_update, cfg->scan_int_delay / 1e-3);
+  return 0;
+}
+
+/*?
+ * The '<em>show ip scan-neighbor</em>' command can be used to show the current
+ * periodic IP neighbor scan parameters
+ *
+ * @cliexpar
+ * Example of showing IP neighbor scan current parameters:
+ * @cliexcmd{show ip neighbor-scan}
+?*/
+/* *INDENT-OFF* */
+VLIB_CLI_COMMAND (show_ip_scan_neighbor_command, static) = {
+  .path = "show ip scan-neighbor",
+  .function = show_ip_neighbor_scan,
+  .short_help = "show ip scan-neighbor",
+  .is_mp_safe = 1,
+};
+/* *INDENT-ON* */
+
+/*
+ * fd.io coding-style-patch-verification: ON
+ *
+ * Local Variables:
+ * eval: (c-set-style "gnu")
+ * End:
+ */

--- a/src/vnet/ip/ip_neighbor.h
+++ b/src/vnet/ip/ip_neighbor.h
@@ -1,0 +1,46 @@
+/*
+ * ip_neighboor.h: ip neighbor generic services
+ *
+ * Copyright (c) 2018 Cisco and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef included_ip_neighbor_h
+#define included_ip_neighbor_h
+
+#define IP_SCAN_DISABLED	0
+#define IP_SCAN_V4_NEIGHBORS	(1 << 0)
+#define IP_SCAN_V6_NEIGHBORS	(1 << 1)
+#define IP_SCAN_V46_NEIGHBORS	(IP_SCAN_V4_NEIGHBORS | IP_SCAN_V6_NEIGHBORS)
+
+typedef struct
+{
+  u8 mode;			/* 0: disable, 1: ip4, 2: ip6, 3: both */
+  u8 scan_interval;		/* neighbor scan interval in minutes */
+  u8 max_proc_time;		/* max processing time per run, in usecs */
+  u8 max_update;		/* max probe/delete operations per run */
+  u8 scan_int_delay;		/* delay in msecs, to resume scan on max */
+  u8 stale_threshold;		/* Threashold in minutes to delete nei entry */
+} ip_neighbor_scan_arg_t;
+
+void ip_neighbor_scan_enable_disable (ip_neighbor_scan_arg_t * arg);
+
+#endif /* included_ip_neighbor_h */
+
+/*
+ * fd.io coding-style-patch-verification: ON
+ *
+ * Local Variables:
+ * eval: (c-set-style "gnu")
+ * End:
+ */

--- a/src/vnet/l2/l2_fib.c
+++ b/src/vnet/l2/l2_fib.c
@@ -1120,9 +1120,6 @@ l2fib_scan (vlib_main_t * vm, f64 start_time, u8 event_only)
   return delta_t + accum_t;
 }
 
-/* Maximum f64 value */
-#define TIME_MAX (1.7976931348623157e+308)
-
 static uword
 l2fib_mac_age_scanner_process (vlib_main_t * vm, vlib_node_runtime_t * rt,
 			       vlib_frame_t * f)
@@ -1131,7 +1128,7 @@ l2fib_mac_age_scanner_process (vlib_main_t * vm, vlib_node_runtime_t * rt,
   l2fib_main_t *fm = &l2fib_main;
   l2learn_main_t *lm = &l2learn_main;
   bool enabled = 0;
-  f64 start_time, next_age_scan_time = TIME_MAX;
+  f64 start_time, next_age_scan_time = CLIB_TIME_MAX;
 
   while (1)
     {
@@ -1190,7 +1187,7 @@ l2fib_mac_age_scanner_process (vlib_main_t * vm, vlib_node_runtime_t * rt,
 	  if (enabled)
 	    next_age_scan_time = start_time + L2FIB_AGE_SCAN_INTERVAL;
 	  else
-	    next_age_scan_time = TIME_MAX;
+	    next_age_scan_time = CLIB_TIME_MAX;
 	}
     }
   return 0;

--- a/src/vpp/api/custom_dump.c
+++ b/src/vpp/api/custom_dump.c
@@ -19,6 +19,7 @@
 
 #include <vnet/vnet.h>
 #include <vnet/ip/ip.h>
+#include <vnet/ip/ip_neighbor.h>
 #include <vnet/unix/tuntap.h>
 #include <vnet/mpls/mpls.h>
 #include <vnet/dhcp/dhcp_proxy.h>
@@ -1898,6 +1899,37 @@ static void *vl_api_interface_name_renumber_t_print
   FINISH;
 }
 
+static void *vl_api_ip_scan_neighbor_enable_disable_t_print
+  (vl_api_ip_scan_neighbor_enable_disable_t * mp, void *handle)
+{
+  u8 *s;
+
+  s = format (0, "SCRIPT: ip_scan_neighbor_enable_disable ");
+
+  switch (mp->mode)
+    {
+    case IP_SCAN_V4_NEIGHBORS:
+      s = format (s, "ip4 ");
+      break;
+    case IP_SCAN_V6_NEIGHBORS:
+      s = format (s, "ip6 ");
+      break;
+    case IP_SCAN_V46_NEIGHBORS:
+      s = format (s, "both ");
+      break;
+    default:
+      s = format (s, "disable ");
+    }
+
+  s = format (s, "interval %d ", mp->scan_interval);
+  s = format (s, "max-time %d ", mp->max_proc_time);
+  s = format (s, "max-update %d ", mp->max_update);
+  s = format (s, "delay %d ", mp->scan_int_delay);
+  s = format (s, "stale %d ", mp->stale_threshold);
+
+  FINISH;
+}
+
 static void *vl_api_want_ip4_arp_events_t_print
   (vl_api_want_ip4_arp_events_t * mp, void *handle)
 {
@@ -3395,6 +3427,7 @@ _(L2_FIB_TABLE_DUMP, l2_fib_table_dump)                                 \
 _(VXLAN_GPE_ADD_DEL_TUNNEL, vxlan_gpe_add_del_tunnel) 			\
 _(VXLAN_GPE_TUNNEL_DUMP, vxlan_gpe_tunnel_dump)                         \
 _(INTERFACE_NAME_RENUMBER, interface_name_renumber)			\
+_(IP_SCAN_NEIGHBOR_ENABLE_DISABLE, ip_scan_neighbor_enable_disable)     \
 _(WANT_IP4_ARP_EVENTS, want_ip4_arp_events)                             \
 _(WANT_IP6_ND_EVENTS, want_ip6_nd_events)                               \
 _(WANT_L2_MACS_EVENTS, want_l2_macs_events)                             \

--- a/src/vppinfra/pool.h
+++ b/src/vppinfra/pool.h
@@ -473,6 +473,9 @@ do {									\
     (_pool_var (rv) < vec_len (P) ?                                     \
      clib_bitmap_next_clear (_pool_var (p)->free_bitmap, _pool_var(rv)) \
      : ~0);                                                             \
+  _pool_var(rv) =                                                       \
+    (_pool_var (rv) < vec_len (P) ?                                     \
+     _pool_var (rv) : ~0);						\
   _pool_var(rv);                                                        \
 })
 

--- a/src/vppinfra/time.h
+++ b/src/vppinfra/time.h
@@ -198,6 +198,9 @@ clib_time_now_internal (clib_time_t * c, u64 n)
   return t * c->seconds_per_clock;
 }
 
+/* Maximum f64 value as max clib_time */
+#define CLIB_TIME_MAX (1.7976931348623157e+308)
+
 always_inline f64
 clib_time_now (clib_time_t * c)
 {


### PR DESCRIPTION
Scan IPv4 and IPv6 neigbor pool entries once a minute to keep them
up to date. The neighbor of an entry is probed if its time-stamp
is older than 1 minute. If the neighbor respond, its time-stamp
will be updated. If there is no response from a neighbor, its
entry will be deleted when the time-stamp of the entry become more
than 4 minutes old. Static neighbor entries are not probed nor
deleted.

Implemented CLI and API to enable and disable priodic scan of IPv4,
IPv6 or both types of IP neighbors. CLI is "ip scan-neighbor" and
API is "ip_scan_neighbor_enable_disable". Other IP neighbor scan
parameters can also be changed from their defaults via the CLI/API.

Change-Id: Id1a0a934ace15d03db845aa698bcbb9cdabebfcd
Signed-off-by: John Lo <loj@cisco.com>