### PR TITLE
Fix context field position in API definition

### DIFF
--- a/src/vnet/ip/ip.api
+++ b/src/vnet/ip/ip.api
@@ -550,8 +550,8 @@ define ip_unnumbered_dump
 
 define ip_details
 {
-  u32 sw_if_index;
   u32 context;
+  u32 sw_if_index;
   u8 is_ipv6;
 };
 

--- a/src/vnet/lisp-gpe/lisp_gpe.api
+++ b/src/vnet/lisp-gpe/lisp_gpe.api
@@ -64,8 +64,8 @@ manual_print manual_endian define gpe_add_del_fwd_entry
 
 define gpe_add_del_fwd_entry_reply
 {
-  i32 retval;
   u32 context;
+  i32 retval;
   u32 fwd_entry_index;
 };
 


### PR DESCRIPTION
- context should be first field for reply messages,
  just like it is for all other 545 replies

Change-Id: Ib291036d3389dbc26c8e9194966d01cab81534aa
Signed-off-by: Ondrej Fabry <ofabry@cisco.com>