### PR TITLE
NAT44: fix next_src_nat (VPP-1384)

### DIFF
--- a/src/plugins/nat/out2in.c
+++ b/src/plugins/nat/out2in.c
@@ -1717,13 +1717,13 @@ icmp_get_ed_key(ip4_header_t *ip0, nat_ed_ses_key_t *p_key0)
 
 static int
 next_src_nat (snat_main_t * sm, ip4_header_t * ip, u8 proto, u16 src_port,
-              u16 dst_port, u32 thread_index)
+              u16 dst_port, u32 thread_index, u32 rx_fib_index)
 {
   clib_bihash_kv_16_8_t kv, value;
   snat_main_per_thread_data_t *tsm = &sm->per_thread_data[thread_index];
 
   make_ed_kv (&kv, &ip->src_address, &ip->dst_address, proto,
-              sm->inside_fib_index, src_port, dst_port);
+              rx_fib_index, src_port, dst_port);
   if (!clib_bihash_search_16_8 (&tsm->in2out_ed, &kv, &value))
     return 1;
 
@@ -1875,7 +1875,8 @@ icmp_match_out2in_ed (snat_main_t * sm, vlib_node_runtime_t * node,
           else
             {
               dont_translate = 1;
-              if (next_src_nat(sm, ip, key.proto, key.l_port, key.r_port, thread_index))
+              if (next_src_nat(sm, ip, key.proto, key.l_port, key.r_port,
+                               thread_index, rx_fib_index))
                 {
                   next = NAT44_ED_OUT2IN_NEXT_IN2OUT;
                   goto out;
@@ -2200,7 +2201,7 @@ nat44_ed_out2in_node_fn_inline (vlib_main_t * vm,
                         {
                           if (next_src_nat(sm, ip0, ip0->protocol,
                                            udp0->src_port, udp0->dst_port,
-                                           thread_index))
+                                           thread_index, rx_fib_index0))
                             {
                               next0 = NAT44_ED_OUT2IN_NEXT_IN2OUT;
                               goto trace00;
@@ -2404,7 +2405,7 @@ nat44_ed_out2in_node_fn_inline (vlib_main_t * vm,
                         {
                           if (next_src_nat(sm, ip1, ip1->protocol,
                                            udp1->src_port, udp1->dst_port,
-                                           thread_index))
+                                           thread_index, rx_fib_index1))
                             {
                               next1 = NAT44_ED_OUT2IN_NEXT_IN2OUT;
                               goto trace01;
@@ -2640,7 +2641,7 @@ nat44_ed_out2in_node_fn_inline (vlib_main_t * vm,
                         {
                           if (next_src_nat(sm, ip0, ip0->protocol,
                                            udp0->src_port, udp0->dst_port,
-                                           thread_index))
+                                           thread_index, rx_fib_index0))
                             {
                               next0 = NAT44_ED_OUT2IN_NEXT_IN2OUT;
                               goto trace0;


### PR DESCRIPTION
Use rx_fib_index instead of sm->inside_fib_index for session lookup key.

Change-Id: I2d6cce5b9376fa8ac4d75a9bbfa8498be0fd1493
Signed-off-by: Matus Fabian <matfabia@cisco.com>