### PR TITLE
VPP-1392: VXLAN fails with IP fragmentation

### DIFF
--- a/src/vnet/ip/ip4_forward.c
+++ b/src/vnet/ip/ip4_forward.c
@@ -2062,7 +2062,7 @@ ip4_mtu_check (vlib_buffer_t * b, u16 packet_len,
 	{
 	  /* IP fragmentation */
 	  ip_frag_set_vnet_buffer (b, 0, adj_packet_bytes,
-				   IP4_FRAG_NEXT_IP4_LOOKUP, 0);
+				   IP4_FRAG_NEXT_IP4_REWRITE, 0);
 	  *next = IP4_REWRITE_NEXT_FRAGMENT;
 	}
     }

--- a/src/vnet/ip/ip6_forward.c
+++ b/src/vnet/ip/ip6_forward.c
@@ -1567,7 +1567,7 @@ ip6_mtu_check (vlib_buffer_t * b, u16 packet_bytes,
 	{
 	  /* IP fragmentation */
 	  ip_frag_set_vnet_buffer (b, 0, adj_packet_bytes,
-				   IP6_FRAG_NEXT_IP6_LOOKUP, 0);
+				   IP6_FRAG_NEXT_IP6_REWRITE, 0);
 	  *next = IP6_REWRITE_NEXT_FRAGMENT;
 	}
       else

--- a/src/vnet/ip/ip_frag.c
+++ b/src/vnet/ip/ip_frag.c
@@ -573,6 +573,7 @@ VLIB_REGISTER_NODE (ip4_frag_node) = {
 
   .n_next_nodes = IP4_FRAG_N_NEXT,
   .next_nodes = {
+    [IP4_FRAG_NEXT_IP4_REWRITE] = "ip4-rewrite",
     [IP4_FRAG_NEXT_IP4_LOOKUP] = "ip4-lookup",
     [IP4_FRAG_NEXT_IP6_LOOKUP] = "ip6-lookup",
     [IP4_FRAG_NEXT_ICMP_ERROR] = "ip4-icmp-error",
@@ -594,6 +595,7 @@ VLIB_REGISTER_NODE (ip6_frag_node) = {
 
   .n_next_nodes = IP6_FRAG_N_NEXT,
   .next_nodes = {
+    [IP6_FRAG_NEXT_IP6_REWRITE] = "ip6-rewrite",
     [IP6_FRAG_NEXT_IP4_LOOKUP] = "ip4-lookup",
     [IP6_FRAG_NEXT_IP6_LOOKUP] = "ip6-lookup",
     [IP6_FRAG_NEXT_DROP] = "ip6-drop"

--- a/src/vnet/ip/ip_frag.h
+++ b/src/vnet/ip/ip_frag.h
@@ -48,6 +48,7 @@ extern vlib_node_registration_t ip6_frag_node;
 
 typedef enum
 {
+  IP4_FRAG_NEXT_IP4_REWRITE,
   IP4_FRAG_NEXT_IP4_LOOKUP,
   IP4_FRAG_NEXT_IP6_LOOKUP,
   IP4_FRAG_NEXT_ICMP_ERROR,
@@ -59,6 +60,7 @@ typedef enum
 {
   IP6_FRAG_NEXT_IP4_LOOKUP,
   IP6_FRAG_NEXT_IP6_LOOKUP,
+  IP6_FRAG_NEXT_IP6_REWRITE,
   IP6_FRAG_NEXT_DROP,
   IP6_FRAG_N_NEXT
 } ip6_frag_next_t;


### PR DESCRIPTION
Not only is it wasteful to send all fragments back through ip4-lookup, but
it doesn't work with tunnel mechanisms that don't have IP enabled on their
payload side.

Change-Id: Ic92d95982dddaa70969a2a6ea2f98edec7614425
Signed-off-by: Ole Troan <ot@cisco.com>